### PR TITLE
Serve public and operator APIs separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,6 @@ export DATABASE_URL=postgresql://hexstody:hexstody@localhost:5432/hexstody
 How to build and run:
 ```
 cargo test
+cd hexstody-hot
 cargo run --bin hexstody-hot -- serve
-```
-
-# Swagger
-
-The binary can produce OpenAPI specification:
-```
-cargo run --bin hexstody-hot -- swagger-public
 ```

--- a/Rocket.toml
+++ b/Rocket.toml
@@ -1,6 +1,0 @@
-[default]
-template_dir = "hexstody-hot/templates"
-
-[default.shutdown]
-ctrlc = false
-signals = ["term", "hup"]

--- a/hexstody-hot/Rocket.toml
+++ b/hexstody-hot/Rocket.toml
@@ -1,0 +1,10 @@
+[default]
+template_dir = "templates"
+public_api_enabled = true
+public_api_port = 8000
+operator_api_enabled = true
+operator_api_port = 8001
+
+[default.shutdown]
+ctrlc = false
+signals = ["term", "hup"]

--- a/hexstody-hot/src/api/mod.rs
+++ b/hexstody-hot/src/api/mod.rs
@@ -1,1 +1,2 @@
 pub mod public;
+pub mod operator;

--- a/hexstody-hot/src/api/operator.rs
+++ b/hexstody-hot/src/api/operator.rs
@@ -1,7 +1,7 @@
 use rocket::fs::{relative, FileServer};
 use rocket::{self, get, routes};
 use rocket_dyn_templates::Template;
-use rocket_okapi::{openapi, openapi_get_routes, swagger_ui::*};
+use rocket_okapi::{openapi, swagger_ui::*};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{Mutex, Notify};
@@ -21,7 +21,7 @@ pub async fn serve_operator_api(
     state: Arc<Mutex<State>>,
     state_notify: Arc<Notify>,
     port: u16
-) -> () {
+) -> Result<(), rocket::Error> {
     let figment = rocket::Config::figment().merge(("port", port));
     rocket::custom(figment)
         .mount("/", routes![index])
@@ -35,5 +35,6 @@ pub async fn serve_operator_api(
         )
         .attach(Template::fairing())
         .launch()
-        .await;
+        .await?;
+    Ok(())
 }

--- a/hexstody-hot/src/api/operator.rs
+++ b/hexstody-hot/src/api/operator.rs
@@ -1,0 +1,39 @@
+use rocket::fs::{relative, FileServer};
+use rocket::{self, get, routes};
+use rocket_dyn_templates::Template;
+use rocket_okapi::{openapi, openapi_get_routes, swagger_ui::*};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{Mutex, Notify};
+
+use hexstody_db::state::State;
+use hexstody_db::Pool;
+
+#[openapi(skip)]
+#[get("/")]
+fn index() -> Template {
+    let context = HashMap::from([("title", "Index"), ("parent", "base")]);
+    Template::render("index", context)
+}
+
+pub async fn serve_operator_api(
+    pool: Pool,
+    state: Arc<Mutex<State>>,
+    state_notify: Arc<Notify>,
+    port: u16
+) -> () {
+    let figment = rocket::Config::figment().merge(("port", port));
+    rocket::custom(figment)
+        .mount("/", routes![index])
+        .mount("/static", FileServer::from(relative!("static/")))
+        .mount(
+            "/swagger/",
+            make_swagger_ui(&SwaggerUIConfig {
+                url: "../openapi.json".to_owned(),
+                ..Default::default()
+            }),
+        )
+        .attach(Template::fairing())
+        .launch()
+        .await;
+}

--- a/hexstody-hot/src/api/public.rs
+++ b/hexstody-hot/src/api/public.rs
@@ -1,6 +1,6 @@
 use rocket::fs::{relative, FileServer};
 use rocket::response::content;
-use rocket::{get, routes};
+use rocket::{get};
 use rocket_dyn_templates::Template;
 use rocket_okapi::{openapi, openapi_get_routes, swagger_ui::*};
 use std::sync::Arc;
@@ -20,7 +20,7 @@ pub async fn serve_public_api(
     state: Arc<Mutex<State>>,
     state_notify: Arc<Notify>,
     port: u16,
-) -> () {
+) -> Result<(), rocket::Error> {
     let figment = rocket::Config::figment().merge(("port", port));
     rocket::custom(figment)
         .mount("/static", FileServer::from(relative!("static/")))
@@ -34,7 +34,8 @@ pub async fn serve_public_api(
         )
         .attach(Template::fairing())
         .launch()
-        .await;
+        .await?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/hexstody-hot/src/api/public.rs
+++ b/hexstody-hot/src/api/public.rs
@@ -3,7 +3,6 @@ use rocket::response::content;
 use rocket::{get, routes};
 use rocket_dyn_templates::Template;
 use rocket_okapi::{openapi, openapi_get_routes, swagger_ui::*};
-use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{Mutex, Notify};
 
@@ -16,22 +15,16 @@ fn ping() -> content::Json<()> {
     content::Json(())
 }
 
-#[openapi(skip)]
-#[get("/")]
-fn index() -> Template {
-    let context = HashMap::from([("title", "Index"), ("parent", "base")]);
-    Template::render("index", context)
-}
-
 pub async fn serve_public_api(
     pool: Pool,
     state: Arc<Mutex<State>>,
     state_notify: Arc<Notify>,
+    port: u16,
 ) -> () {
-    rocket::build()
+    let figment = rocket::Config::figment().merge(("port", port));
+    rocket::custom(figment)
         .mount("/static", FileServer::from(relative!("static/")))
         .mount("/", openapi_get_routes![ping])
-        .mount("/", routes![index])
         .mount(
             "/swagger/",
             make_swagger_ui(&SwaggerUIConfig {
@@ -71,7 +64,7 @@ mod tests {
             let state = state_mx.clone();
             let state_notify = state_notify.clone();
             async move {
-                let serve_task = serve_public_api(pool, state, state_notify);
+                let serve_task = serve_public_api(pool, state, state_notify, SERVICE_TEST_PORT);
                 futures::pin_mut!(serve_task);
                 futures::future::select(serve_task, receiver.map_err(drop)).await;
             }

--- a/hexstody-hot/src/main.rs
+++ b/hexstody-hot/src/main.rs
@@ -3,7 +3,9 @@ mod api;
 use clap::Parser;
 use futures::future::{AbortHandle, Abortable, Aborted};
 use log::*;
+use serde::Deserialize;
 use std::error::Error;
+use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Mutex, Notify};
@@ -11,9 +13,10 @@ use tokio::time::sleep;
 
 use hexstody_db::create_db_pool;
 use hexstody_db::queries::query_state;
+use hexstody_db::{state::State, Pool};
 
+use api::operator::*;
 use api::public::*;
-
 
 #[derive(Parser, Debug, Clone)]
 #[clap(about, version, author)]
@@ -35,41 +38,118 @@ struct Args {
 #[derive(Parser, Debug, Clone)]
 enum SubCommand {
     /// Start listening incoming API requests
-    Serve
+    Serve,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+enum ApiType {
+    Public,
+    Operator,
+}
+
+impl fmt::Display for ApiType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ApiType::Public => write!(f, "Public"),
+            ApiType::Operator => write!(f, "Operator"),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ApiConfig {
+    public_api_enabled: bool,
+    public_api_port: u16,
+    operator_api_enabled: bool,
+    operator_api_port: u16,
+}
+
+fn parse_api_config() -> ApiConfig {
+    let figment = rocket::Config::figment();
+    let public_api_enabled = figment.extract_inner("public_api_enabled").unwrap_or(true);
+    let public_api_port = figment.extract_inner("public_api_port").unwrap_or(8000);
+    let operator_api_enabled = figment
+        .extract_inner("operator_api_enabled")
+        .unwrap_or(true);
+    let operator_api_port = figment.extract_inner("operator_api_port").unwrap_or(8001);
+    ApiConfig {
+        public_api_enabled,
+        public_api_port,
+        operator_api_enabled,
+        operator_api_port,
+    }
+}
+
+async fn serve_api(
+    pool: Pool,
+    state_mx: Arc<Mutex<State>>,
+    state_notify: Arc<Notify>,
+    api_type: ApiType,
+    api_enabled: bool,
+    port: u16,
+) -> () {
+    if !api_enabled {
+        info!("{api_type} API disabled");
+        return ();
+    };
+    info!("Serving {api_type} API");
+    match api_type {
+        ApiType::Public => loop {
+            let (_abort_api_handle, abort_api_reg) = AbortHandle::new_pair();
+            let api_fut = tokio::spawn(serve_public_api(
+                pool.clone(),
+                state_mx.clone(),
+                state_notify.clone(),
+                port,
+            ));
+            match Abortable::new(api_fut, abort_api_reg).await {
+                Ok(_) => (),
+                Err(Aborted) => {
+                    error!("{api_type} API thread aborted")
+                }
+            }
+            let restart_dt = Duration::from_secs(5);
+            info!(
+                "Adding {:?} delay before restarting {api_type} API logic",
+                restart_dt
+            );
+            sleep(restart_dt).await;
+        },
+        ApiType::Operator => tokio::spawn(serve_operator_api(pool, state_mx, state_notify, port)),
+    };
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
+    let api_config = parse_api_config();
     env_logger::init();
-
     match args.subcmd.clone() {
-        SubCommand::Serve => loop {
-            let args = args.clone();
-            let (_abort_api_handle, abort_api_reg) = AbortHandle::new_pair();
-
+        SubCommand::Serve => {
             info!("Connecting to database");
             let pool = create_db_pool(&args.dbconnect).await?;
             info!("Connected");
-
             info!("Reconstructing state from database");
             let state = query_state(&pool).await?;
             let state_mx = Arc::new(Mutex::new(state));
             let state_notify = Arc::new(Notify::new());
-
-            info!("Serving API");
-
-            let public_api_fut = tokio::spawn(serve_public_api(pool, state_mx, state_notify));
-            match Abortable::new(public_api_fut, abort_api_reg).await {
-                Ok(mres) => (),
-                Err(Aborted) => {
-                    error!("API thread aborted")
-                }
-            }
-
-            let restart_dt = Duration::from_secs(5);
-            info!("Adding {:?} delay before restarting logic", restart_dt);
-            sleep(restart_dt).await;
+            let public_api_fut = serve_api(
+                pool.clone(),
+                state_mx.clone(),
+                state_notify.clone(),
+                ApiType::Public,
+                api_config.public_api_enabled,
+                api_config.public_api_port,
+            );
+            let operator_api_fut = serve_api(
+                pool,
+                state_mx,
+                state_notify,
+                ApiType::Operator,
+                api_config.operator_api_enabled,
+                api_config.operator_api_port,
+            );
+            tokio::join!(public_api_fut, operator_api_fut);
         }
     }
     Ok(())


### PR DESCRIPTION
Here the public and operator APIs are devided into separate Rocket web server instances.
This PR also allows to change configuration of APIs from `hexstody-hot` crate via `hexstody-hot/Rocket.toml` file:

- One can enable or disable API
- Port on which the API is served is also configurable

Related to #2 and #3.