### PR TITLE
Btc withdraw i37

### DIFF
--- a/hexstody-api/src/domain/currency.rs
+++ b/hexstody-api/src/domain/currency.rs
@@ -111,3 +111,31 @@ impl fmt::Display for EthAccount {
         write!(f, "{}", self.account)
     }
 }
+
+#[derive(
+    Debug, Serialize, Deserialize, JsonSchema, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
+pub struct BTCTxid {pub txid: String}
+
+#[derive(
+    Debug, Serialize, Deserialize, JsonSchema, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
+pub struct ETHTxid {pub txid: String}
+
+#[derive(
+    Debug, Serialize, Deserialize, JsonSchema, Clone, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
+#[serde(tag = "type")]
+pub enum CurrencyTxId {
+    BTC(BTCTxid),
+    ETH(ETHTxid),
+}
+
+impl fmt::Display for CurrencyTxId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CurrencyTxId::BTC(BTCTxid{txid}) => write!(f, "{}", txid),
+            CurrencyTxId::ETH(ETHTxid{txid}) => write!(f, "{}", txid),
+        }
+    }
+}

--- a/hexstody-api/src/types.rs
+++ b/hexstody-api/src/types.rs
@@ -181,8 +181,10 @@ pub enum WithdrawalRequestStatus {
     InProgress {
         confirmations: i16,
     },
-    Completed,
-    Confirmed {
+    /// Enough confirmations is collected
+    Confirmed,
+    /// Withdrawal tx is posted
+    Completed {
         confirmed_at: NaiveDateTime,
         txid: CurrencyTxId
     },

--- a/hexstody-api/src/types.rs
+++ b/hexstody-api/src/types.rs
@@ -16,6 +16,8 @@ use rocket_okapi::{
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::domain::CurrencyTxId;
+
 use super::domain::currency::{BtcAddress, Currency, CurrencyAddress};
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -179,7 +181,11 @@ pub enum WithdrawalRequestStatus {
     InProgress {
         confirmations: i16,
     },
-    Confirmed,
+    Completed,
+    Confirmed {
+        confirmed_at: NaiveDateTime,
+        txid: CurrencyTxId
+    },
     Rejected,
 }
 

--- a/hexstody-api/src/types.rs
+++ b/hexstody-api/src/types.rs
@@ -188,7 +188,10 @@ pub enum WithdrawalRequestStatus {
         confirmed_at: NaiveDateTime,
         txid: CurrencyTxId
     },
-    Rejected,
+    OpRejected,
+    NodeRejected {
+        reason: String
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]

--- a/hexstody-api/src/types.rs
+++ b/hexstody-api/src/types.rs
@@ -181,15 +181,20 @@ pub enum WithdrawalRequestStatus {
     InProgress {
         confirmations: i16,
     },
-    /// Enough confirmations is collected
+    /// Confirmed by operators, but not yet sent to the node
     Confirmed,
-    /// Withdrawal tx is posted
+    /// Tx sent to the node
     Completed {
+        /// Time when the request was processed
         confirmed_at: NaiveDateTime,
+        /// Txid
         txid: CurrencyTxId
     },
+    /// Rejected by operators
     OpRejected,
+    /// Rejected by the node
     NodeRejected {
+        /// Node
         reason: String
     }
 }

--- a/hexstody-btc/src/api/public.rs
+++ b/hexstody-btc/src/api/public.rs
@@ -103,6 +103,7 @@ async fn withdraw_btc(
     cfg: &State<WithdrawCfg>,
     cw: Json<ConfirmedWithdrawal>
 ) -> error::Result<WithdrawalResponse>{
+    debug!("{:?}", cw);
     let WithdrawCfg { min_confirmations, op_public_keys, hot_domain } = cfg.inner();
     let mut valid_confirms = 0;
     let mut valid_rejections = 0;
@@ -134,7 +135,7 @@ async fn withdraw_btc(
             valid_rejections = valid_rejections + 1;
         };
     };
-
+    debug!("Confirms/rejections: {}/{}", valid_confirms, valid_rejections);
     if (valid_confirms > valid_rejections) && (valid_confirms-valid_rejections >= min_confirmations) {
         if let CurrencyAddress::BTC(hexstody_api::domain::BtcAddress{addr}) = &cw.address {
             if let Ok(addr) = bitcoin::Address::from_str(addr.as_str()){
@@ -149,6 +150,7 @@ async fn withdraw_btc(
                         }))
                     })?;
                 let resp = WithdrawalResponse{ id: cw.id.clone(), txid: BtcTxid(txid) };
+                debug!("OK: {:?}", resp);
                 Ok(Json(resp))
             } else {
                 Err((Status::BadRequest, Json(crate::api::error::ErrorMessage {

--- a/hexstody-db/src/state/user.rs
+++ b/hexstody-db/src/state/user.rs
@@ -18,6 +18,8 @@ pub struct UserInfo {
     /// Withdrawal requests for given user. The id can be used to retreive the body of request.
     /// Here goes only withdrawals that are not yet fully performed.
     pub withdrawal_requests: HashSet<WithdrawalRequestId>,
+    /// Completed withdrawal requests
+    pub completed_requests: HashSet<WithdrawalRequestId>,
     /// Information for each currency
     pub currencies: HashMap<Currency, UserCurrencyInfo>,
 }
@@ -29,6 +31,7 @@ impl UserInfo {
             auth,
             created_at,
             withdrawal_requests: HashSet::new(),
+            completed_requests: HashSet::new(),
             currencies: Currency::supported()
                 .into_iter()
                 .map(|c| (c.clone(), UserCurrencyInfo::new(c)))

--- a/hexstody-db/src/state/user.rs
+++ b/hexstody-db/src/state/user.rs
@@ -98,7 +98,8 @@ impl UserCurrencyInfo {
                 }
             })
             .sum();
-        let pending_withdrawals: u64 = self.withdrawal_requests.iter().map(|(_, w)| w.amount).sum();
+        // Do not count rejected withdrawals
+        let pending_withdrawals: u64 = self.withdrawal_requests.iter().map(|(_, w)| if w.is_rejected() {0} else {w.amount}).sum();
 
         // zero to prevent spreading overflow bug when in less then out
         0.max(tx_sum - pending_withdrawals as i64) as u64
@@ -117,7 +118,8 @@ impl UserCurrencyInfo {
                 }
             })
             .sum();
-        let pending_withdrawals: u64 = self.withdrawal_requests.iter().map(|(_, w)| w.amount).sum();
+        // Do not count rejected withdrawals
+        let pending_withdrawals: u64 = self.withdrawal_requests.iter().map(|(_, w)| if w.is_rejected() {0} else {w.amount}).sum();
 
         // zero to prevent spreading overflow bug when in less then out
         0.max(tx_sum - pending_withdrawals as i64) as u64

--- a/hexstody-db/src/state/withdraw.rs
+++ b/hexstody-db/src/state/withdraw.rs
@@ -19,15 +19,20 @@ pub type WithdrawalRequestId = Uuid;
 pub enum WithdrawalRequestStatus {
     /// Number of confirmations minus number of rejections received
     InProgress(i16),
+    /// Confirmed by operators, but not yet sent to the node
     Confirmed,
+    /// Tx sent to the node
     Completed {
         /// Time when the request was processed
         confirmed_at: NaiveDateTime,
         /// Txid
         txid: CurrencyTxId
     },
+    /// Rejected by operators
     OpRejected,
+    /// Rejected by the node
     NodeRejected {
+        /// Node
         reason: String
     }
 }

--- a/hexstody-db/src/state/withdraw.rs
+++ b/hexstody-db/src/state/withdraw.rs
@@ -19,8 +19,8 @@ pub type WithdrawalRequestId = Uuid;
 pub enum WithdrawalRequestStatus {
     /// Number of confirmations minus number of rejections received
     InProgress(i16),
-    Completed,
-    Confirmed {
+    Confirmed,
+    Completed {
         /// Time when the request was processed
         confirmed_at: NaiveDateTime,
         /// Txid
@@ -33,8 +33,8 @@ impl Into<WithdrawalRequestStatusApi> for WithdrawalRequestStatus {
     fn into(self) -> WithdrawalRequestStatusApi {
         match self {
             WithdrawalRequestStatus::InProgress(n) => WithdrawalRequestStatusApi::InProgress { confirmations: n },
-            WithdrawalRequestStatus::Completed => WithdrawalRequestStatusApi::Completed,
-            WithdrawalRequestStatus::Confirmed { confirmed_at, txid } => WithdrawalRequestStatusApi::Confirmed { confirmed_at, txid},
+            WithdrawalRequestStatus::Confirmed => WithdrawalRequestStatusApi::Confirmed,
+            WithdrawalRequestStatus::Completed { confirmed_at, txid } => WithdrawalRequestStatusApi::Completed { confirmed_at, txid},
             WithdrawalRequestStatus::Rejected => WithdrawalRequestStatusApi::Rejected,
         }
     }

--- a/hexstody-db/src/state/withdraw.rs
+++ b/hexstody-db/src/state/withdraw.rs
@@ -26,7 +26,10 @@ pub enum WithdrawalRequestStatus {
         /// Txid
         txid: CurrencyTxId
     },
-    Rejected,
+    OpRejected,
+    NodeRejected {
+        reason: String
+    }
 }
 
 impl Into<WithdrawalRequestStatusApi> for WithdrawalRequestStatus {
@@ -35,7 +38,8 @@ impl Into<WithdrawalRequestStatusApi> for WithdrawalRequestStatus {
             WithdrawalRequestStatus::InProgress(n) => WithdrawalRequestStatusApi::InProgress { confirmations: n },
             WithdrawalRequestStatus::Confirmed => WithdrawalRequestStatusApi::Confirmed,
             WithdrawalRequestStatus::Completed { confirmed_at, txid } => WithdrawalRequestStatusApi::Completed { confirmed_at, txid},
-            WithdrawalRequestStatus::Rejected => WithdrawalRequestStatusApi::Rejected,
+            WithdrawalRequestStatus::OpRejected => WithdrawalRequestStatusApi::OpRejected,
+            WithdrawalRequestStatus::NodeRejected{reason} => WithdrawalRequestStatusApi::NodeRejected{reason}
         }
     }
 }
@@ -86,6 +90,16 @@ impl Into<WithdrawalRequestApi> for WithdrawalRequest {
             created_at: self.created_at.format("%Y-%m-%d %H:%M:%S").to_string(),
             amount: self.amount,
             confirmation_status: confirmation_status,
+        }
+    }
+}
+
+impl WithdrawalRequest {
+    pub fn is_rejected(&self) -> bool {
+        match self.status {
+            WithdrawalRequestStatus::OpRejected => true,
+            WithdrawalRequestStatus::NodeRejected{..} => true,
+            _ => false
         }
     }
 }

--- a/hexstody-db/src/update/mod.rs
+++ b/hexstody-db/src/update/mod.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 use self::btc::{BestBtcBlock, BtcTxCancel};
 use self::deposit::DepositAddress;
 use self::signup::SignupInfo;
-use self::withdrawal::{WithdrawalRequestDecisionInfo, WithdrawalRequestInfo, WithdrawConfirmedInfo};
+use self::withdrawal::{WithdrawalRequestDecisionInfo, WithdrawalRequestInfo, WithdrawCompleteInfo};
 use super::state::transaction::BtcTransaction;
 use super::state::State;
 
@@ -46,7 +46,7 @@ pub enum UpdateBody {
     /// New operator's decision for the withdrawal request
     WithdrawalRequestDecision(WithdrawalRequestDecisionInfo),
     /// Set withdraw request to confirmed
-    WithdrawalRequestConfirm(WithdrawConfirmedInfo),
+    WithdrawalRequestComplete(WithdrawCompleteInfo),
     /// Register new deposit address for user
     DepositAddress(DepositAddress),
     /// New best block for BTC
@@ -64,7 +64,7 @@ impl UpdateBody {
             UpdateBody::Snapshot(_) => UpdateTag::Snapshot,
             UpdateBody::CreateWithdrawalRequest(_) => UpdateTag::CreateWithdrawalRequest,
             UpdateBody::WithdrawalRequestDecision(_) => UpdateTag::WithdrawalRequestDecision,
-            UpdateBody::WithdrawalRequestConfirm(_) => UpdateTag::WithdrawalRequestConfirm,
+            UpdateBody::WithdrawalRequestComplete(_) => UpdateTag::WithdrawalRequestConfirm,
             UpdateBody::DepositAddress(_) => UpdateTag::DepositAddress,
             UpdateBody::BestBtcBlock(_) => UpdateTag::BestBtcBlock,
             UpdateBody::UpdateBtcTx(_) => UpdateTag::UpdateBtcTx,
@@ -78,7 +78,7 @@ impl UpdateBody {
             UpdateBody::Snapshot(v) => serde_json::to_value(v),
             UpdateBody::CreateWithdrawalRequest(v) => serde_json::to_value(v),
             UpdateBody::WithdrawalRequestDecision(v) => serde_json::to_value(v),
-            UpdateBody::WithdrawalRequestConfirm(v) => serde_json::to_value(v),
+            UpdateBody::WithdrawalRequestComplete(v) => serde_json::to_value(v),
             UpdateBody::DepositAddress(v) => serde_json::to_value(v),
             UpdateBody::BestBtcBlock(v) => serde_json::to_value(v),
             UpdateBody::UpdateBtcTx(v) => serde_json::to_value(v),
@@ -182,7 +182,7 @@ impl UpdateTag {
             UpdateTag::WithdrawalRequestDecision => Ok(UpdateBody::WithdrawalRequestDecision(
                 serde_json::from_value(value)?,
             )),
-            UpdateTag::WithdrawalRequestConfirm => Ok(UpdateBody::WithdrawalRequestConfirm(
+            UpdateTag::WithdrawalRequestConfirm => Ok(UpdateBody::WithdrawalRequestComplete(
                 serde_json::from_value(value)?,
             )),
             UpdateTag::DepositAddress => {

--- a/hexstody-db/src/update/mod.rs
+++ b/hexstody-db/src/update/mod.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 use self::btc::{BestBtcBlock, BtcTxCancel};
 use self::deposit::DepositAddress;
 use self::signup::SignupInfo;
-use self::withdrawal::{WithdrawalRequestDecisionInfo, WithdrawalRequestInfo};
+use self::withdrawal::{WithdrawalRequestDecisionInfo, WithdrawalRequestInfo, WithdrawConfirmedInfo};
 use super::state::transaction::BtcTransaction;
 use super::state::State;
 
@@ -45,6 +45,8 @@ pub enum UpdateBody {
     CreateWithdrawalRequest(WithdrawalRequestInfo),
     /// New operator's decision for the withdrawal request
     WithdrawalRequestDecision(WithdrawalRequestDecisionInfo),
+    /// Set withdraw request to confirmed
+    WithdrawalRequestConfirm(WithdrawConfirmedInfo),
     /// Register new deposit address for user
     DepositAddress(DepositAddress),
     /// New best block for BTC
@@ -62,6 +64,7 @@ impl UpdateBody {
             UpdateBody::Snapshot(_) => UpdateTag::Snapshot,
             UpdateBody::CreateWithdrawalRequest(_) => UpdateTag::CreateWithdrawalRequest,
             UpdateBody::WithdrawalRequestDecision(_) => UpdateTag::WithdrawalRequestDecision,
+            UpdateBody::WithdrawalRequestConfirm(_) => UpdateTag::WithdrawalRequestConfirm,
             UpdateBody::DepositAddress(_) => UpdateTag::DepositAddress,
             UpdateBody::BestBtcBlock(_) => UpdateTag::BestBtcBlock,
             UpdateBody::UpdateBtcTx(_) => UpdateTag::UpdateBtcTx,
@@ -75,6 +78,7 @@ impl UpdateBody {
             UpdateBody::Snapshot(v) => serde_json::to_value(v),
             UpdateBody::CreateWithdrawalRequest(v) => serde_json::to_value(v),
             UpdateBody::WithdrawalRequestDecision(v) => serde_json::to_value(v),
+            UpdateBody::WithdrawalRequestConfirm(v) => serde_json::to_value(v),
             UpdateBody::DepositAddress(v) => serde_json::to_value(v),
             UpdateBody::BestBtcBlock(v) => serde_json::to_value(v),
             UpdateBody::UpdateBtcTx(v) => serde_json::to_value(v),
@@ -89,6 +93,7 @@ pub enum UpdateTag {
     Snapshot,
     CreateWithdrawalRequest,
     WithdrawalRequestDecision,
+    WithdrawalRequestConfirm,
     DepositAddress,
     BestBtcBlock,
     UpdateBtcTx,
@@ -113,6 +118,7 @@ impl fmt::Display for UpdateTag {
             UpdateTag::Snapshot => write!(f, "snapshot"),
             UpdateTag::CreateWithdrawalRequest => write!(f, "withdrawal request"),
             UpdateTag::WithdrawalRequestDecision => write!(f, "withdrawal request decision"),
+            UpdateTag::WithdrawalRequestConfirm => write!(f, "withdrawal request confirm"),
             UpdateTag::DepositAddress => write!(f, "deposit address"),
             UpdateTag::BestBtcBlock => write!(f, "best btc block"),
             UpdateTag::UpdateBtcTx => write!(f, "update btc tx"),
@@ -130,6 +136,7 @@ impl FromStr for UpdateTag {
             "snapshot" => Ok(UpdateTag::Snapshot),
             "withdrawal request" => Ok(UpdateTag::CreateWithdrawalRequest),
             "withdrawal request decision" => Ok(UpdateTag::WithdrawalRequestDecision),
+            "withdrawal request confirm" => Ok(UpdateTag::WithdrawalRequestConfirm),
             "deposit address" => Ok(UpdateTag::DepositAddress),
             "best btc block" => Ok(UpdateTag::BestBtcBlock),
             "update btc tx" => Ok(UpdateTag::UpdateBtcTx),
@@ -173,6 +180,9 @@ impl UpdateTag {
                 serde_json::from_value(value)?,
             )),
             UpdateTag::WithdrawalRequestDecision => Ok(UpdateBody::WithdrawalRequestDecision(
+                serde_json::from_value(value)?,
+            )),
+            UpdateTag::WithdrawalRequestConfirm => Ok(UpdateBody::WithdrawalRequestConfirm(
                 serde_json::from_value(value)?,
             )),
             UpdateTag::DepositAddress => {

--- a/hexstody-db/src/update/mod.rs
+++ b/hexstody-db/src/update/mod.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 use self::btc::{BestBtcBlock, BtcTxCancel};
 use self::deposit::DepositAddress;
 use self::signup::SignupInfo;
-use self::withdrawal::{WithdrawalRequestDecisionInfo, WithdrawalRequestInfo, WithdrawCompleteInfo};
+use self::withdrawal::{WithdrawalRequestDecisionInfo, WithdrawalRequestInfo, WithdrawCompleteInfo, WithdrawalRejectInfo};
 use super::state::transaction::BtcTransaction;
 use super::state::State;
 
@@ -47,6 +47,8 @@ pub enum UpdateBody {
     WithdrawalRequestDecision(WithdrawalRequestDecisionInfo),
     /// Set withdraw request to confirmed
     WithdrawalRequestComplete(WithdrawCompleteInfo),
+    /// Withdrawal request rejected by the node
+    WithdrawalRequestNodeRejected(WithdrawalRejectInfo),
     /// Register new deposit address for user
     DepositAddress(DepositAddress),
     /// New best block for BTC
@@ -65,6 +67,7 @@ impl UpdateBody {
             UpdateBody::CreateWithdrawalRequest(_) => UpdateTag::CreateWithdrawalRequest,
             UpdateBody::WithdrawalRequestDecision(_) => UpdateTag::WithdrawalRequestDecision,
             UpdateBody::WithdrawalRequestComplete(_) => UpdateTag::WithdrawalRequestConfirm,
+            UpdateBody::WithdrawalRequestNodeRejected(_) => UpdateTag::WithdrawalRequestNodeRejected,
             UpdateBody::DepositAddress(_) => UpdateTag::DepositAddress,
             UpdateBody::BestBtcBlock(_) => UpdateTag::BestBtcBlock,
             UpdateBody::UpdateBtcTx(_) => UpdateTag::UpdateBtcTx,
@@ -79,6 +82,7 @@ impl UpdateBody {
             UpdateBody::CreateWithdrawalRequest(v) => serde_json::to_value(v),
             UpdateBody::WithdrawalRequestDecision(v) => serde_json::to_value(v),
             UpdateBody::WithdrawalRequestComplete(v) => serde_json::to_value(v),
+            UpdateBody::WithdrawalRequestNodeRejected(v) => serde_json::to_value(v),
             UpdateBody::DepositAddress(v) => serde_json::to_value(v),
             UpdateBody::BestBtcBlock(v) => serde_json::to_value(v),
             UpdateBody::UpdateBtcTx(v) => serde_json::to_value(v),
@@ -94,6 +98,7 @@ pub enum UpdateTag {
     CreateWithdrawalRequest,
     WithdrawalRequestDecision,
     WithdrawalRequestConfirm,
+    WithdrawalRequestNodeRejected,
     DepositAddress,
     BestBtcBlock,
     UpdateBtcTx,
@@ -119,6 +124,7 @@ impl fmt::Display for UpdateTag {
             UpdateTag::CreateWithdrawalRequest => write!(f, "withdrawal request"),
             UpdateTag::WithdrawalRequestDecision => write!(f, "withdrawal request decision"),
             UpdateTag::WithdrawalRequestConfirm => write!(f, "withdrawal request confirm"),
+            UpdateTag::WithdrawalRequestNodeRejected => write!(f, "withdrawal request node rejected"),
             UpdateTag::DepositAddress => write!(f, "deposit address"),
             UpdateTag::BestBtcBlock => write!(f, "best btc block"),
             UpdateTag::UpdateBtcTx => write!(f, "update btc tx"),
@@ -137,6 +143,7 @@ impl FromStr for UpdateTag {
             "withdrawal request" => Ok(UpdateTag::CreateWithdrawalRequest),
             "withdrawal request decision" => Ok(UpdateTag::WithdrawalRequestDecision),
             "withdrawal request confirm" => Ok(UpdateTag::WithdrawalRequestConfirm),
+            "withdrawal request node rejected" => Ok(UpdateTag::WithdrawalRequestNodeRejected),
             "deposit address" => Ok(UpdateTag::DepositAddress),
             "best btc block" => Ok(UpdateTag::BestBtcBlock),
             "update btc tx" => Ok(UpdateTag::UpdateBtcTx),
@@ -185,6 +192,7 @@ impl UpdateTag {
             UpdateTag::WithdrawalRequestConfirm => Ok(UpdateBody::WithdrawalRequestComplete(
                 serde_json::from_value(value)?,
             )),
+            UpdateTag::WithdrawalRequestNodeRejected => Ok(UpdateBody::WithdrawalRequestNodeRejected(serde_json::from_value(value)?)),
             UpdateTag::DepositAddress => {
                 Ok(UpdateBody::DepositAddress(serde_json::from_value(value)?))
             }

--- a/hexstody-db/src/update/withdrawal.rs
+++ b/hexstody-db/src/update/withdrawal.rs
@@ -126,3 +126,9 @@ pub struct WithdrawCompleteInfo {
     pub confirmed_at: NaiveDateTime,
     pub txid: CurrencyTxId
 }
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct WithdrawalRejectInfo {
+    pub id: WithdrawalRequestId,
+    pub reason: String
+}

--- a/hexstody-db/src/update/withdrawal.rs
+++ b/hexstody-db/src/update/withdrawal.rs
@@ -1,10 +1,11 @@
+use chrono::NaiveDateTime;
 use p256::{ecdsa::Signature, PublicKey};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::state::withdraw::WithdrawalRequestId;
 use crate::update::signup::UserId;
-use hexstody_api::domain::{Currency, CurrencyAddress};
+use hexstody_api::domain::{Currency, CurrencyAddress, CurrencyTxId};
 use hexstody_api::types::{
     ConfirmationData, SignatureData, WithdrawalRequestInfo as WithdrawalRequestInfoApi, WithdrawalRequestDecisionType
 };
@@ -115,4 +116,13 @@ impl From<WithdrawalRequestDecision> for SignatureData {
             public_key: wrd.public_key,
         }
     }
+}
+
+/// This data type is passed for an update.
+/// Contains information required to set withdraw request to confirmed
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct WithdrawConfirmedInfo {
+    pub id: WithdrawalRequestId,
+    pub confirmed_at: NaiveDateTime,
+    pub txid: CurrencyTxId
 }

--- a/hexstody-db/src/update/withdrawal.rs
+++ b/hexstody-db/src/update/withdrawal.rs
@@ -121,7 +121,7 @@ impl From<WithdrawalRequestDecision> for SignatureData {
 /// This data type is passed for an update.
 /// Contains information required to set withdraw request to confirmed
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-pub struct WithdrawConfirmedInfo {
+pub struct WithdrawCompleteInfo {
     pub id: WithdrawalRequestId,
     pub confirmed_at: NaiveDateTime,
     pub txid: CurrencyTxId

--- a/hexstody-hot/src/runner.rs
+++ b/hexstody-hot/src/runner.rs
@@ -309,8 +309,9 @@ pub async fn run_hot_wallet(
     let update_response_hndl = tokio::spawn({
         let state_mx = state_mx.clone();
         let btc_client = btc_client.clone();
+        let update_sender = update_sender.clone();
         async move {
-            update_results_worker(btc_client, state_mx, update_resp_receiver).await;
+            update_results_worker(btc_client, state_mx, update_resp_receiver, update_sender).await;
         }    
     });
 

--- a/hexstody-hot/src/worker.rs
+++ b/hexstody-hot/src/worker.rs
@@ -4,7 +4,7 @@ use hexstody_btc_api::events::*;
 use hexstody_btc_client::client::BtcClient;
 use hexstody_db::{
     state::State,
-    update::{btc::BestBtcBlock, StateUpdate, UpdateBody, results::UpdateResult, withdrawal::WithdrawConfirmedInfo},
+    update::{btc::BestBtcBlock, StateUpdate, UpdateBody, results::UpdateResult, withdrawal::WithdrawCompleteInfo},
 };
 use log::*;
 use std::sync::Arc;
@@ -43,7 +43,7 @@ pub async fn update_results_worker(
                             Ok(resp) => {
                                 debug!("withdraw_btc_resp: {:?}", resp);
                                 let txid = resp.txid.0.to_string();
-                                let bod = UpdateBody::WithdrawalRequestConfirm(WithdrawConfirmedInfo{
+                                let bod = UpdateBody::WithdrawalRequestComplete(WithdrawCompleteInfo{
                                     id: resp.id,
                                     confirmed_at: Utc::now().naive_utc(),
                                     txid: CurrencyTxId::BTC(BTCTxid{txid})

--- a/hexstody-operator/static/scripts/index.js
+++ b/hexstody-operator/static/scripts/index.js
@@ -189,8 +189,11 @@ function addStatusCell(row, status) {
         case "Confirmed":
             cellText = document.createTextNode("Confirmed");
             break;
-        case "Rejected":
-            cellText = document.createTextNode("Rejected");
+        case "OpRejected":
+            cellText = document.createTextNode("Rejected by operators");
+            break;
+        case "NodeRejected":
+            cellText = document.createTextNode("Rejected by node (" + status.reason + ")");
             break;
         case "Completed":
             cellText = document.createTextNode("Completed");

--- a/hexstody-operator/static/scripts/index.js
+++ b/hexstody-operator/static/scripts/index.js
@@ -192,6 +192,9 @@ function addStatusCell(row, status) {
         case "Rejected":
             cellText = document.createTextNode("Rejected");
             break;
+        case "Completed":
+            cellText = document.createTextNode("Completed");
+            break;
         default:
             cellText = document.createTextNode("Unknown");
     };

--- a/hexstody-public/src/api/wallet.rs
+++ b/hexstody-public/src/api/wallet.rs
@@ -14,7 +14,6 @@ use hexstody_api::error;
 use hexstody_api::types as api;
 use hexstody_btc_client::client::{BtcClient, BTC_BYTES_PER_TRANSACTION};
 use hexstody_db::state::State as DbState;
-use hexstody_db::state::WithdrawalRequestStatus;
 use hexstody_db::state::{Transaction, WithdrawalRequest, REQUIRED_NUMBER_OF_CONFIRMATIONS};
 use hexstody_db::update::deposit::DepositAddress;
 use hexstody_db::update::{StateUpdate, UpdateBody};
@@ -109,13 +108,7 @@ pub async fn get_history(
         currency: &Currency,
         withdrawal: &WithdrawalRequest,
     ) -> api::HistoryItem {
-        let withdrawal_status = match &withdrawal.status {
-            WithdrawalRequestStatus::InProgress(n) => {
-                api::WithdrawalRequestStatus::InProgress { confirmations: *n }
-            }
-            WithdrawalRequestStatus::Confirmed => api::WithdrawalRequestStatus::Confirmed,
-            WithdrawalRequestStatus::Rejected => api::WithdrawalRequestStatus::Rejected,
-        };
+        let withdrawal_status = withdrawal.status.clone().into();
 
         api::HistoryItem::Withdrawal(api::WithdrawalHistoryItem {
             currency: currency.to_owned(),

--- a/hexstody-public/static/scripts/page/overview.js
+++ b/hexstody-public/static/scripts/page/overview.js
@@ -32,8 +32,12 @@ async function initTemplates() {
                 return "In progress";
             case "Confirmed":
                 return "Confirmed";
-            case "Rejected":
-                return "Rejected";
+            case "Completed":
+                return "Completed";
+            case "OpRejected":
+                return "Rejected by operators";
+            case "NodeRejected":
+                return "Rejected by node";
             default:
                 return "Unknown";
         };


### PR DESCRIPTION
* Store TxId for completed withdrawals in ``WithdrawalRequestStatus``
* Distinguish between withdrawals rejected by the operators and ones rejected by the node
* Count only non-rejected withdrawals towards the balance

``` rust

pub enum WithdrawalRequestStatus {
    /// Number of confirmations minus number of rejections received
    InProgress(i16),
    /// Confirmed by operators, but not yet sent to the node
    Confirmed,
    /// Tx sent to the node
    Completed {
        /// Time when the request was processed
        confirmed_at: NaiveDateTime,
        /// Txid
        txid: CurrencyTxId
    },
    /// Rejected by operators
    OpRejected,
    /// Rejected by the node
    NodeRejected {
        /// Node
        reason: String
    }
}
```