### PR TITLE
I82 tokens page

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,11 @@ Run vscode with export to allow rust extension to validate sqlx macros
 ```
 (export DATABASE_URL=postgres://hexstody:hexstody@localhost/hexstody; code)
 ```
+
+Run sass watcher to auto-compile hexstody-public/static/css/styles.scss on every change:
+
+```
+sass --watch --sourcemap=none hexstody-public/static/css/styles.scss:hexstody-public/static/css/styles.css
+```
+
+Omit `--watch` to compile once. `sass` is available in nix-shell 

--- a/hexstody-api/src/domain/currency.rs
+++ b/hexstody-api/src/domain/currency.rs
@@ -1,7 +1,7 @@
 use bitcoin;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::fmt;
+use std::{fmt, vec};
 
 /// A currency that custody understands. Can be extended in future.
 #[derive(
@@ -57,7 +57,31 @@ impl Currency {
             _ => None
         }).collect()
     }
+
+    pub fn default_tokens() -> Vec<Erc20Token> {
+        let supported_tickers = vec!["USDT".to_string(), "GTECH".to_string()];
+        Currency::supported().into_iter().filter_map(|c| match c {
+            Currency::ERC20(token) => if supported_tickers.contains(&token.ticker) {Some(token)} else {None},
+            _ => None
+        }).collect()
+    }
+
+    /// List of currencies active by default for a new user
+    pub fn default_currencies() -> Vec<Currency> {
+        Currency::supported().into_iter().filter_map(|c| match c.clone() {
+            Currency::ERC20(token) => if token.ticker == "CRV" {None} else {Some(c)},
+            _ => Some(c)
+        }).collect()
+    }
 }
+
+pub fn filter_tokens(curs: Vec<Currency>) -> Vec<Erc20Token> {
+    curs.into_iter().filter_map(|c| match c {
+        Currency::ERC20(token) => Some(token),
+        _ => None
+    }).collect()
+}
+
 
 /// Description of ERC20 token that allows to distinguish them between each other
 #[derive(

--- a/hexstody-api/src/domain/currency.rs
+++ b/hexstody-api/src/domain/currency.rs
@@ -42,6 +42,14 @@ impl Currency {
                                     })
             ]
     }
+
+    /// Check if the currency is a token
+    pub fn is_token(&self) -> bool {
+        match self {
+            Currency::ERC20(_) => true,
+            _ => false,
+        }
+    }
 }
 
 /// Description of ERC20 token that allows to distinguish them between each other

--- a/hexstody-api/src/domain/currency.rs
+++ b/hexstody-api/src/domain/currency.rs
@@ -50,6 +50,13 @@ impl Currency {
             _ => false,
         }
     }
+
+    pub fn supported_tokens() -> Vec<Erc20Token> {
+        Currency::supported().into_iter().filter_map(|c| match c {
+            Currency::ERC20(token) => Some(token),
+            _ => None
+        }).collect()
+    }
 }
 
 /// Description of ERC20 token that allows to distinguish them between each other

--- a/hexstody-api/src/error.rs
+++ b/hexstody-api/src/error.rs
@@ -1,4 +1,4 @@
-use crate::domain::currency::Currency;
+use crate::domain::{currency::Currency, Erc20Token};
 use rocket::http::Status;
 use rocket::serde::json::Json;
 use rocket_okapi::okapi::schemars::JsonSchema;
@@ -43,7 +43,15 @@ pub enum Error {
     #[error("Not enough {0}!")]
     InsufficientFunds(Currency),
     #[error("Failed to connect to ETH node: {0}")]
-    FailedETHConnection(String)
+    FailedETHConnection(String),
+    #[error("{0} is already enabled")]
+    TokenAlreadyEnabled(Erc20Token),
+    #[error("{0} is already disabled")]
+    TokenAlreadyDisabled(Erc20Token),
+    #[error("{0} has non-zero balance. Can not disable")]
+    TokenNonZeroBalance(Erc20Token),
+    #[error("Token action failed: {0}")]
+    TokenActionFailed(String)
 }
 
 impl Error {
@@ -63,6 +71,10 @@ impl Error {
             Error::FailedGetFee(_) => 11,
             Error::InsufficientFunds(_) => 12,
             Error::FailedETHConnection(_) => 13,
+            Error::TokenAlreadyEnabled(_) => 14,
+            Error::TokenAlreadyDisabled(_) => 15,
+            Error::TokenNonZeroBalance(_) => 16,
+            Error::TokenActionFailed(_) => 17,
         }
     }
 
@@ -82,6 +94,10 @@ impl Error {
             Error::FailedGetFee(_) => Status::from_code(500).unwrap(),
             Error::InsufficientFunds(_) =>  Status::from_code(500).unwrap(),
             Error::FailedETHConnection(_) => Status::from_code(500).unwrap(),
+            Error::TokenAlreadyEnabled(_) => Status::from_code(500).unwrap(),
+            Error::TokenAlreadyDisabled(_) => Status::from_code(500).unwrap(),
+            Error::TokenNonZeroBalance(_) => Status::from_code(500).unwrap(),
+            Error::TokenActionFailed(_) => Status::from_code(500).unwrap()
         }
     }
 }

--- a/hexstody-api/src/error.rs
+++ b/hexstody-api/src/error.rs
@@ -42,6 +42,8 @@ pub enum Error {
     FailedGetFee(Currency),
     #[error("Not enough {0}!")]
     InsufficientFunds(Currency),
+    #[error("Failed to connect to ETH node: {0}")]
+    FailedETHConnection(String)
 }
 
 impl Error {
@@ -60,6 +62,7 @@ impl Error {
             Error::FailedGenAddress(_) => 10,
             Error::FailedGetFee(_) => 11,
             Error::InsufficientFunds(_) => 12,
+            Error::FailedETHConnection(_) => 13,
         }
     }
 
@@ -78,6 +81,7 @@ impl Error {
             Error::FailedGenAddress(_) => Status::from_code(500).unwrap(),
             Error::FailedGetFee(_) => Status::from_code(500).unwrap(),
             Error::InsufficientFunds(_) =>  Status::from_code(500).unwrap(),
+            Error::FailedETHConnection(_) => Status::from_code(500).unwrap(),
         }
     }
 }

--- a/hexstody-api/src/types.rs
+++ b/hexstody-api/src/types.rs
@@ -578,3 +578,12 @@ pub struct WithdrawalResponse {
     /// Output addresses
     pub output_addresses: Vec<CurrencyAddress>,
 }
+
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct TokenInfo {
+    pub token: Erc20Token,
+    pub balance: u64,
+    pub finalized_balance: u64,
+    
+}

--- a/hexstody-api/src/types.rs
+++ b/hexstody-api/src/types.rs
@@ -20,6 +20,7 @@ use crate::domain::CurrencyTxId;
 
 use super::domain::currency::{BtcAddress, Currency, CurrencyAddress, Erc20Token};
 
+#[allow(non_snake_case)]
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct TickerETH {
     pub USD: f32,
@@ -40,6 +41,7 @@ pub struct Erc20HistResp {
     pub result: Vec<Erc20HistUnit>
 }
 
+#[allow(non_snake_case)]
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct EthHistUnit {
     pub blockNumber: String,
@@ -64,6 +66,7 @@ pub struct EthHistUnit {
     pub functionName: String,
 }
 
+#[allow(non_snake_case)]
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct EthHistUnitU {
     pub blockNumber: String,
@@ -79,6 +82,7 @@ pub struct EthHistUnitU {
     pub addr: String
 }
 
+#[allow(non_snake_case)]
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct Erc20HistUnit {
     pub blockNumber: String,
@@ -102,6 +106,7 @@ pub struct Erc20HistUnit {
     pub confirmations: String,
 }
 
+#[allow(non_snake_case)]
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
 pub struct Erc20HistUnitU {
     pub blockNumber: String,
@@ -125,6 +130,7 @@ pub struct UserEth{
  ,pub data    : UserData
 }
 
+#[allow(non_snake_case)]
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct UserData{
     pub tokens: Vec<Erc20Token>,
@@ -134,7 +140,7 @@ pub struct UserData{
     pub balanceTokens: Vec<Erc20TokenBalance>
 }
 
-
+#[allow(non_snake_case)]
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct Erc20TokenBalance{
     pub tokenName: String,
@@ -155,6 +161,7 @@ pub struct EthFeeResp {
     pub result: EthGasPrice
 }
 
+#[allow(non_snake_case)]
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct EthGasPrice {
     pub LastBlock: String,

--- a/hexstody-api/src/types.rs
+++ b/hexstody-api/src/types.rs
@@ -588,9 +588,19 @@ pub struct WithdrawalResponse {
 
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct GetTokensResponse {
+    pub tokens: Vec<TokenInfo>
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct TokenInfo {
     pub token: Erc20Token,
     pub balance: u64,
     pub finalized_balance: u64,
-    
+    pub is_active: bool
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct TokenActionRequest{
+    pub token: Erc20Token
 }

--- a/hexstody-db/src/state/user.rs
+++ b/hexstody-db/src/state/user.rs
@@ -33,7 +33,7 @@ impl UserInfo {
             created_at,
             withdrawal_requests: HashSet::new(),
             completed_requests: HashSet::new(),
-            currencies: Currency::supported()
+            currencies: Currency::default_currencies()
                 .into_iter()
                 .map(|c| (c.clone(), UserCurrencyInfo::new(c)))
                 .collect(),

--- a/hexstody-db/src/update/mod.rs
+++ b/hexstody-db/src/update/mod.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 use self::btc::{BestBtcBlock, BtcTxCancel};
 use self::deposit::DepositAddress;
 use self::signup::SignupInfo;
-use self::withdrawal::{WithdrawalRequestDecisionInfo, WithdrawalRequestInfo, WithdrawCompleteInfo, WithdrawalRejectInfo};
+use self::withdrawal::{WithdrawalRequestDecisionInfo, WithdrawalRequestInfo, WithdrawCompleteInfo, WithdrawalRejectInfo, TokenUpdate};
 use super::state::transaction::BtcTransaction;
 use super::state::State;
 
@@ -57,6 +57,8 @@ pub enum UpdateBody {
     UpdateBtcTx(BtcTransaction),
     /// Cancel BTC transaction
     CancelBtcTx(BtcTxCancel),
+    /// Update token list
+    UpdateTokens(TokenUpdate),
 }
 
 impl UpdateBody {
@@ -72,6 +74,7 @@ impl UpdateBody {
             UpdateBody::BestBtcBlock(_) => UpdateTag::BestBtcBlock,
             UpdateBody::UpdateBtcTx(_) => UpdateTag::UpdateBtcTx,
             UpdateBody::CancelBtcTx(_) => UpdateTag::CancelBtcTx,
+            UpdateBody::UpdateTokens(_) => UpdateTag::UpdateTokens,
         }
     }
 
@@ -87,6 +90,7 @@ impl UpdateBody {
             UpdateBody::BestBtcBlock(v) => serde_json::to_value(v),
             UpdateBody::UpdateBtcTx(v) => serde_json::to_value(v),
             UpdateBody::CancelBtcTx(v) => serde_json::to_value(v),
+            UpdateBody::UpdateTokens(v) => serde_json::to_value(v),
         }
     }
 }
@@ -103,6 +107,7 @@ pub enum UpdateTag {
     BestBtcBlock,
     UpdateBtcTx,
     CancelBtcTx,
+    UpdateTokens
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
@@ -129,6 +134,7 @@ impl fmt::Display for UpdateTag {
             UpdateTag::BestBtcBlock => write!(f, "best btc block"),
             UpdateTag::UpdateBtcTx => write!(f, "update btc tx"),
             UpdateTag::CancelBtcTx => write!(f, "cancel btc tx"),
+            UpdateTag::UpdateTokens => write!(f, "update tokens")
         }
     }
 }
@@ -148,6 +154,7 @@ impl FromStr for UpdateTag {
             "best btc block" => Ok(UpdateTag::BestBtcBlock),
             "update btc tx" => Ok(UpdateTag::UpdateBtcTx),
             "cancel btc tx" => Ok(UpdateTag::CancelBtcTx),
+            "update tokens" => Ok(UpdateTag::UpdateTokens),
             _ => Err(UnknownUpdateTag(s.to_owned())),
         }
     }
@@ -199,6 +206,7 @@ impl UpdateTag {
             UpdateTag::BestBtcBlock => Ok(UpdateBody::BestBtcBlock(serde_json::from_value(value)?)),
             UpdateTag::UpdateBtcTx => Ok(UpdateBody::UpdateBtcTx(serde_json::from_value(value)?)),
             UpdateTag::CancelBtcTx => Ok(UpdateBody::CancelBtcTx(serde_json::from_value(value)?)),
+            UpdateTag::UpdateTokens => Ok(UpdateBody::UpdateTokens(serde_json::from_value(value)?))
         }
     }
 }

--- a/hexstody-db/src/update/withdrawal.rs
+++ b/hexstody-db/src/update/withdrawal.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use crate::state::withdraw::WithdrawalRequestId;
 use crate::update::signup::UserId;
-use hexstody_api::domain::{Currency, CurrencyAddress, CurrencyTxId};
+use hexstody_api::domain::{Currency, CurrencyAddress, CurrencyTxId, Erc20Token};
 use hexstody_api::types::{
     ConfirmationData, SignatureData, WithdrawalRequestDecisionType,
     WithdrawalRequestInfo as WithdrawalRequestInfoApi,
@@ -135,4 +135,17 @@ pub struct WithdrawCompleteInfo {
 pub struct WithdrawalRejectInfo {
     pub id: WithdrawalRequestId,
     pub reason: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub enum TokenAction {
+    Enable,
+    Disable
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct TokenUpdate{
+    pub user: UserId,
+    pub token: Erc20Token,
+    pub action: TokenAction
 }

--- a/hexstody-hot/src/tests/mod.rs
+++ b/hexstody-hot/src/tests/mod.rs
@@ -146,7 +146,7 @@ async fn test_btc_rbf_0conf_deposit() {
 
         let balances = env.hot_client.get_balance().await.expect("Balances");
         assert_eq!(
-            Some(amount),
+            Some(Amount::from_sat(0)),
             balances
                 .by_currency(&Currency::BTC)
                 .map(|i| Amount::from_sat(i.value.try_into().expect("Positive balance")))

--- a/hexstody-public/src/api/auth.rs
+++ b/hexstody-public/src/api/auth.rs
@@ -1,3 +1,4 @@
+use hexstody_api::domain::Currency;
 use hexstody_api::error;
 use hexstody_api::types as api;
 use hexstody_db::state::*;
@@ -35,25 +36,20 @@ pub async fn signup_email(
         return Err(error::Error::UserPasswordTooLong.into());
     }
 
-    {
-        let mstate = state.lock().await;
-        if let Some(_) = mstate.users.get(&data.user) {
-            return Err(error::Error::SignupExistedUser.into());
-        } else {
-            reqwest::get("http://localhost:8000/createuser/".to_owned() + &data.user)
-                .await
-                .unwrap()
-                .text()
-                .await
-                .unwrap();
-            let body = reqwest::get(&("http://node.desolator.net/createuser/".to_owned()+&data.user)).await.unwrap().text().await;
-            let pass_hash = bcrypt::hash(&data.password).map_err(|e| error::Error::from(e))?;
-            let upd = StateUpdate::new(UpdateBody::Signup(SignupInfo {
-                username: data.user.clone(),
-                auth: SignupAuth::Password(pass_hash),
-            }));
-            updater.send(upd).await.unwrap();
-        }
+    let user_exists = state.lock().await.users.contains_key(&data.user);
+    if user_exists {
+        return Err(error::Error::SignupExistedUser.into());
+    } else {
+        let body = reqwest::get(&("http://node.desolator.net/createuser/".to_owned()+&data.user)).await.unwrap().text().await;
+        if let Err(e) = body {
+            return Err(error::Error::FailedETHConnection(e.to_string()).into())
+        };
+        let pass_hash = bcrypt::hash(&data.password).map_err(|e| error::Error::from(e))?;
+        let upd = StateUpdate::new(UpdateBody::Signup(SignupInfo {
+            username: data.user.clone(),
+            auth: SignupAuth::Password(pass_hash),
+        }));
+        updater.send(upd).await.unwrap();
     }
     Ok(Json(()))
 }

--- a/hexstody-public/src/api/auth.rs
+++ b/hexstody-public/src/api/auth.rs
@@ -1,4 +1,3 @@
-use hexstody_api::domain::Currency;
 use hexstody_api::error;
 use hexstody_api::types as api;
 use hexstody_db::state::*;

--- a/hexstody-public/src/api/auth.rs
+++ b/hexstody-public/src/api/auth.rs
@@ -1,3 +1,4 @@
+use hexstody_api::domain::Currency;
 use hexstody_api::error;
 use hexstody_api::types as api;
 use hexstody_db::state::*;
@@ -8,6 +9,7 @@ use reqwest;
 use rocket::http::{Cookie, CookieJar};
 use rocket::post;
 use rocket::serde::json::Json;
+use rocket::serde::json;
 use rocket::State as RState;
 use rocket_okapi::openapi;
 use std::future::Future;
@@ -39,10 +41,20 @@ pub async fn signup_email(
     if user_exists {
         return Err(error::Error::SignupExistedUser.into());
     } else {
-        let body = reqwest::get(&("http://node.desolator.net/createuser/".to_owned()+&data.user)).await.unwrap().text().await;
+        // Create user
+        let body = reqwest::get(&("http://node.desolator.net/createuser/".to_owned()+&data.user)).await;
+
+        // Set user's default tokens
+        let default_tokens = json::to_string(&Currency::default_tokens()).unwrap();
+        let client = reqwest::Client::new();
+        let res = client.post(&("http://node.desolator.net/tokens/".to_owned()+&data.user)).body(default_tokens).send().await;
         if let Err(e) = body {
             return Err(error::Error::FailedETHConnection(e.to_string()).into())
         };
+        if let Err(e) = res {
+            return Err(error::Error::FailedETHConnection(e.to_string()).into())
+        };
+        
         let pass_hash = bcrypt::hash(&data.password).map_err(|e| error::Error::from(e))?;
         let upd = StateUpdate::new(UpdateBody::Signup(SignupInfo {
             username: data.user.clone(),

--- a/hexstody-public/src/api/mod.rs
+++ b/hexstody-public/src/api/mod.rs
@@ -49,6 +49,13 @@ fn overview() -> Template {
 }
 
 #[openapi(skip)]
+#[get("/tokens")]
+fn tokens() -> Template {
+    let context = HashMap::from([("title", "Token settings"), ("parent", "base_with_header")]);
+    Template::render("tokens", context)
+}
+
+#[openapi(skip)]
 #[get("/signup")]
 fn signup() -> Template {
     let context = HashMap::from([("title", "Sign Up"), ("parent", "base")]);
@@ -152,12 +159,14 @@ pub async fn serve_api(
                 signup_email,
                 signin_email,
                 logout,
-                get_tokens
+                list_tokens,
+                enable_token,
+                disable_token
             ],
         )
         .mount(
             "/",
-            routes![index, overview, signup, signin, deposit, withdraw],
+            routes![index, overview, tokens, signup, signin, deposit, withdraw],
         )
         .mount(
             "/swagger/",

--- a/hexstody-public/src/api/mod.rs
+++ b/hexstody-public/src/api/mod.rs
@@ -151,7 +151,8 @@ pub async fn serve_api(
                 post_withdraw,
                 signup_email,
                 signin_email,
-                logout
+                logout,
+                get_tokens
             ],
         )
         .mount(

--- a/hexstody-public/src/api/wallet.rs
+++ b/hexstody-public/src/api/wallet.rs
@@ -5,11 +5,11 @@ use tokio::sync::{mpsc, Mutex};
 use uuid::Uuid;
 
 use rocket::http::CookieJar;
-use rocket::serde::json::Json;
+use rocket::serde::json::{Json, self};
 use rocket::{get, post, State};
 use rocket_okapi::openapi;
 
-use hexstody_api::domain::{BtcAddress, Currency, CurrencyAddress, CurrencyTxId};
+use hexstody_api::domain::{BtcAddress, Currency, CurrencyAddress, CurrencyTxId, Erc20Token, filter_tokens};
 use super::auth::{require_auth, require_auth_user};
 use hexstody_api::error;
 use hexstody_api::types::{self as api, TokenInfo, GetTokensResponse, TokenActionRequest};
@@ -470,14 +470,26 @@ pub async fn enable_token(
             None => {
                 let state_update = StateUpdate::new(UpdateBody::UpdateTokens(
                     TokenUpdate{ 
-                        user: user.username,
-                        token,
+                        user: user.username.clone(),
+                        token: token.clone(),
                         action: TokenAction::Enable 
                     }));
-                updater
-                    .send(state_update)
-                    .await
-                    .map_err(|e| error::Error::TokenActionFailed(e.to_string()).into())
+                let upd = updater.send(state_update).await;
+                match upd {
+                    Ok(_) => {
+                        let mut tokens = filter_tokens(user.currencies.keys().cloned().collect());
+                        tokens.push(token);
+                        let body = json::to_string(&tokens).unwrap();
+                        reqwest::Client::new()
+                            .post(&("http://node.desolator.net/tokens/".to_owned()+&user.username))
+                            .body(body)
+                            .send()
+                            .await
+                            .map_err(|e| error::Error::FailedETHConnection(e.to_string()).into())
+                            .map(|_| ())
+                    },
+                    Err(e) => Err(error::Error::TokenActionFailed(e.to_string()).into()),
+                }
             }
         }
     }).await
@@ -493,8 +505,8 @@ pub async fn disable_token(
 ) -> error::Result<()>{
     require_auth_user(cookies, state, |_, user| async move {
         let token = req.into_inner().token;
-        let c = Currency::ERC20(token.clone());
-        match user.currencies.get(&c) {
+        let cur = Currency::ERC20(token.clone());
+        match user.currencies.get(&cur) {
             None => Err(error::Error::TokenAlreadyDisabled(token).into()),
             Some(info) => {
                 if info.balance() > 0 {
@@ -502,14 +514,28 @@ pub async fn disable_token(
                 } else {
                     let state_update = StateUpdate::new(UpdateBody::UpdateTokens(
                         TokenUpdate{ 
-                            user: user.username,
-                            token,
+                            user: user.username.clone(),
+                            token: token.clone(),
                             action: TokenAction::Disable 
                         }));
-                    updater
-                        .send(state_update)
-                        .await
-                        .map_err(|e| error::Error::TokenActionFailed(e.to_string()).into())
+                let upd = updater.send(state_update).await;
+                match upd {
+                    Ok(_) => {
+                        let tokens : Vec<Erc20Token> = user.currencies.keys().into_iter().filter_map(|c| match c {
+                            Currency::ERC20(tok) => if tok.ticker == token.ticker {None} else {Some(token.clone())},
+                            _ => None
+                        }).collect();
+                        let body = json::to_string(&tokens).unwrap();
+                        reqwest::Client::new()
+                            .post(&("http://node.desolator.net/tokens/".to_owned()+&user.username))
+                            .body(body)
+                            .send()
+                            .await
+                            .map_err(|e| error::Error::FailedETHConnection(e.to_string()).into())
+                            .map(|_| ())
+                    },
+                    Err(e) => Err(error::Error::TokenActionFailed(e.to_string()).into()),
+                }
                 }
             }
         }

--- a/hexstody-public/src/api/wallet.rs
+++ b/hexstody-public/src/api/wallet.rs
@@ -14,7 +14,7 @@ use super::auth::{require_auth, require_auth_user};
 use hexstody_api::error;
 use hexstody_api::types::{self as api, TokenInfo};
 use hexstody_btc_client::client::{BtcClient, BTC_BYTES_PER_TRANSACTION};
-use hexstody_db::state::{State as DbState, UserCurrencyInfo};
+use hexstody_db::state::{State as DbState};
 use hexstody_db::state::{Transaction, WithdrawalRequest, REQUIRED_NUMBER_OF_CONFIRMATIONS};
 use hexstody_db::update::deposit::DepositAddress;
 use hexstody_db::update::withdrawal::WithdrawalRequestInfo;

--- a/hexstody-public/static/css/custom_styles.scss
+++ b/hexstody-public/static/css/custom_styles.scss
@@ -265,3 +265,11 @@ body {
 
     }
 }
+
+.fit-content{
+    width: fit-content;
+}
+
+.mr-2em{
+    margin-right: 2em;
+}

--- a/hexstody-public/static/css/styles.css
+++ b/hexstody-public/static/css/styles.css
@@ -7914,3 +7914,9 @@ body {
       white-space: nowrap; }
       #history-table .history-col-3 > div .is-deposit {
         color: #409EFF; }
+
+.fit-content {
+  width: fit-content; }
+
+.mr-2em {
+  margin-right: 2em; }

--- a/hexstody-public/static/scripts/page/tokens.js
+++ b/hexstody-public/static/scripts/page/tokens.js
@@ -1,0 +1,112 @@
+import { loadTemplate, formattedCurrencyValue, formattedElapsedTime } from "./common.js";
+
+let tokensTemplate = null;
+const refreshInterval = 20000;
+
+async function getTokens() {
+    return await fetch("/tokens/list").then(r => r.json());
+};
+
+async function postEnable(token) {
+    const body = {token: token}
+    return await fetch("/tokens/enable",
+    {
+        method: "POST",
+        body: JSON.stringify(body)
+    });
+}
+
+async function postDisable(token) {
+    const body = {token: token}
+    return await fetch("/tokens/disable",
+    {
+        method: "POST",
+        body: JSON.stringify(body)
+    });
+}
+
+function buildEnabler(token) {
+    return async function enabler(){
+        console.log("enable " + token.token.tiker)
+        const res = await postEnable(token.token);
+        loadTokens();
+    } 
+}
+
+function buildDisabler(token) {
+    return async function disabler(){
+        console.log("disable " + token.token.ticker)
+        const res = await postDisable(token.token);
+        loadTokens();
+    }
+}
+
+async function initTemplates() {
+
+    const [tokensTemp] = await Promise.allSettled([
+        await loadTemplate("/templates/token.html.hbs")
+    ]);
+
+    tokensTemplate = tokensTemp.value;
+
+    Handlebars.registerHelper('isDeposit', (historyItem) => historyItem.type === "deposit");
+    Handlebars.registerHelper('isWithdrawal', (historyItem) => historyItem.type === "withdrawal");
+    Handlebars.registerHelper('formatWithdrawalStatus', (status) => {
+        switch (status.type) {
+            case "InProgress":
+                return "In progress";
+            case "Confirmed":
+                return "Confirmed";
+            case "Completed":
+                return "Completed";
+            case "OpRejected":
+                return "Rejected by operators";
+            case "NodeRejected":
+                return "Rejected by node";
+            default:
+                return "Unknown";
+        };
+    });
+
+    Handlebars.registerHelper('formatCurrencyName', function () { return this.token.ticker; });
+    Handlebars.registerHelper('truncate', (text, n) => text.slice(0, n) + "...");
+
+    Handlebars.registerHelper('formattedElapsedTime', function () {
+        return formattedElapsedTime(this.date);
+    });
+    Handlebars.registerHelper('isInProgress', (req_confirmations, confirmations) => req_confirmations > confirmations);
+
+}
+
+async function loadTokens() {
+    const tokens = await getTokens();
+    const tokensDrawUpdate = tokensTemplate(tokens);
+    const tokensElem = document.getElementById("tokens");
+    tokensElem.innerHTML = tokensDrawUpdate;
+    const tokensArray = tokens.tokens;
+    tokensArray.forEach(token => {
+        const ticker = token.token.ticker;
+        if (token.is_active) {
+            const btnDisable = document.getElementById("btn-disable-" + ticker);
+            btnDisable.onclick = buildDisabler(token);
+        } else {
+            const btnEnable = document.getElementById("btn-enable-" + ticker);
+            btnEnable.onclick = buildEnabler(token);
+        }
+    });
+}
+
+
+async function updateLoop() {
+    await loadTokens();
+    await new Promise((resolve) => setTimeout(resolve, refreshInterval));
+    updateLoop();
+}
+
+async function init() {
+    await initTemplates();
+    updateLoop();
+};
+
+
+document.addEventListener("DOMContentLoaded", init);

--- a/hexstody-public/static/templates/token.html.hbs
+++ b/hexstody-public/static/templates/token.html.hbs
@@ -1,0 +1,16 @@
+{{#each tokens}}
+<div class="content-row mt-5">
+    <span id="curr-name-{{formatCurrencyName}}" class="item-val-bg mr-2em">
+        {{formatCurrencyName}}
+    </span>
+    {{#if this.is_active}}
+    <button id="btn-disable-{{formatCurrencyName}}" type="button" class="button item-buttom-w">
+        Disable
+    </button>
+    {{else}}
+    <button id="btn-enable-{{formatCurrencyName}}" type="button" class="button is-info item-buttom-d">
+        Enable
+    </button>
+    {{/if}}
+</div>
+{{/each}}

--- a/hexstody-public/templates/header.html.hbs
+++ b/hexstody-public/templates/header.html.hbs
@@ -34,6 +34,11 @@
                     <span>Withdraw</span>
                 </a>
             </div>
+            <div class="navbar-item is-hoverable  has-text-weight-bold">
+                <a class="navbar-item has-text-black" href="/tokens">
+                    <span>Tokens</span>
+                </a>
+            </div>
         </div>
         <div class="navbar-end">
             <div class="navbar-item has-dropdown is-hoverable lang-dropdown has-text-weight-bold nav-account">

--- a/hexstody-public/templates/tokens.html.hbs
+++ b/hexstody-public/templates/tokens.html.hbs
@@ -1,0 +1,26 @@
+{{#*inline "css"}}
+{{/inline}}
+
+{{#*inline "scripts"}}
+<script type="module" src="/scripts/page/common.js"></script>
+<script type="module" src="/scripts/page/tokens.js"></script>
+<script src="/scripts/handlebars.min-v4.7.7.js" defer></script>
+<script src="https://unpkg.com/@popperjs/core@2" defer></script>
+<script src="https://unpkg.com/tippy.js@6" defer></script>
+{{/inline}}
+
+{{#*inline "page"}}
+<div class="full-height" style="background-color: #ECEFF4;">
+
+    <div class="container" style="padding-top: 25px;">
+
+        <div class="box balance-box">
+            <div class="row is-center fit-content" id="tokens">
+            </div>
+        </div>
+    </div>
+
+</div>
+{{/inline}}
+
+{{> base_with_header}}


### PR DESCRIPTION
Add Tokens page which shows all supported tokens and allows the user to enable/disable tokens for the specific user.

It is impossible to disable tokens with non-zero balances (maybe add a threshold to allow dusty balances to be closed?)

ETH-node is notified of all token actions and the list of user's tokens is kept up to date both in h-hot and on the node.

By default new users have USDT and GTECH active. CRV is available as a supported token but must be enabled manually.

close #82 