### PR TITLE
Automatic data update on the operator's dashboard

### DIFF
--- a/hexstody-operator/src/api/mod.rs
+++ b/hexstody-operator/src/api/mod.rs
@@ -2,6 +2,7 @@ use figment::Figment;
 use hexstody_runtime_db::RuntimeState;
 use hexstody_ticker::api::ticker_api;
 use hexstody_ticker_provider::client::TickerClient;
+use qrcode_generator::QrCodeEcc;
 use rocket::{
     fairing::AdHoc,
     fs::{FileServer, NamedFile},
@@ -12,20 +13,23 @@ use rocket_okapi::{openapi, openapi_get_routes, swagger_ui::*};
 use std::{path::PathBuf, str, sync::Arc};
 use tokio::sync::{mpsc, Mutex, Notify};
 use uuid::Uuid;
-use qrcode_generator::QrCodeEcc;
 
 use hexstody_api::{
     domain::Currency,
     error,
     types::{
-        ConfirmationData, HotBalanceResponse, Invite, InviteRequest, InviteResp,
-        LimitChangeDecisionType, LimitChangeOpResponse, LimitConfirmationData, SignatureData,
-        WithdrawalRequest, WithdrawalRequestDecisionType, ExchangeConfirmationData, ExchangeFilter, ExchangeBalanceItem, ExchangeAddress, UserInfo, WithdrawalFilter, LimitChangeFilter,
+        ConfirmationData, ExchangeAddress, ExchangeBalanceItem, ExchangeConfirmationData,
+        ExchangeFilter, HotBalanceResponse, Invite, InviteRequest, InviteResp,
+        LimitChangeDecisionType, LimitChangeFilter, LimitChangeOpResponse, LimitConfirmationData,
+        SignatureData, UserInfo, WithdrawalFilter, WithdrawalRequest,
+        WithdrawalRequestDecisionType,
     },
 };
 use hexstody_btc_client::client::BtcClient;
 use hexstody_db::{
-    state::{State as HexstodyState, REQUIRED_NUMBER_OF_CONFIRMATIONS, exchange::ExchangeDecisionType},
+    state::{
+        exchange::ExchangeDecisionType, State as HexstodyState, REQUIRED_NUMBER_OF_CONFIRMATIONS,
+    },
     update::limit::LimitChangeData,
     update::{misc::InviteRec, StateUpdate, UpdateBody},
     Pool,
@@ -143,7 +147,7 @@ async fn list(
     signature_data: SignatureData,
     config: &RocketState<SignatureVerificationConfig>,
     currency_name: &str,
-    filter: WithdrawalFilter
+    filter: WithdrawalFilter,
 ) -> error::Result<Json<Vec<WithdrawalRequest>>> {
     guard_op_signature_nomsg(
         &config,
@@ -157,8 +161,8 @@ async fn list(
             .values()
             .cloned()
             .filter_map(|x| {
-                if x.address.currency().ticker_lowercase() == currency_name 
-                    && x.matches_filter(filter) 
+                if x.address.currency().ticker_lowercase() == currency_name
+                    && x.matches_filter(filter)
                 {
                     Some(x.into())
                 } else {
@@ -311,7 +315,11 @@ async fn get_all_changes(
     signature_data: SignatureData,
     filter: LimitChangeFilter,
 ) -> error::Result<Json<Vec<LimitChangeOpResponse>>> {
-    guard_op_signature_nomsg(&config, uri!(get_all_changes(&filter)).to_string(), signature_data)?;
+    guard_op_signature_nomsg(
+        &config,
+        uri!(get_all_changes(&filter)).to_string(),
+        signature_data,
+    )?;
     let hexstody_state = state.lock().await;
     let changes = hexstody_state
         .users
@@ -413,7 +421,7 @@ async fn reject_limits(
 }
 
 #[openapi(skip)]
-#[post("/exchange/confirm", data="<confirmation_data>")]
+#[post("/exchange/confirm", data = "<confirmation_data>")]
 async fn confirm_exchange(
     update_sender: &RocketState<mpsc::Sender<StateUpdate>>,
     signature_data: SignatureData,
@@ -444,7 +452,7 @@ async fn confirm_exchange(
 }
 
 #[openapi(skip)]
-#[post("/exchange/reject", data="<confirmation_data>")]
+#[post("/exchange/reject", data = "<confirmation_data>")]
 async fn reject_exchange(
     update_sender: &RocketState<mpsc::Sender<StateUpdate>>,
     signature_data: SignatureData,
@@ -481,7 +489,7 @@ async fn get_exchange_requests(
     state: &RocketState<Arc<Mutex<HexstodyState>>>,
     signature_data: SignatureData,
     config: &RocketState<SignatureVerificationConfig>,
-    filter: ExchangeFilter
+    filter: ExchangeFilter,
 ) -> error::Result<Json<Vec<hexstody_api::types::ExchangeOrder>>> {
     guard_op_signature_nomsg(
         &config,
@@ -507,12 +515,18 @@ async fn get_exchange_balances(
     )?;
     let state = state.lock().await;
     let res = &state.exchange_state.balances;
-    let res = res.into_iter().map(|(k, v)| ExchangeBalanceItem{ currency: k.clone(), balance: v.clone() }).collect();
+    let res = res
+        .into_iter()
+        .map(|(k, v)| ExchangeBalanceItem {
+            currency: k.clone(),
+            balance: v.clone(),
+        })
+        .collect();
     Ok(Json(res))
 }
 
 #[openapi(skip)]
-#[post("/exchange/address", data="<currency>")]
+#[post("/exchange/address", data = "<currency>")]
 async fn get_exchange_address(
     state: &RocketState<Arc<Mutex<HexstodyState>>>,
     btc_client: &RocketState<BtcClient>,
@@ -520,7 +534,7 @@ async fn get_exchange_address(
     update_sender: &RocketState<mpsc::Sender<StateUpdate>>,
     signature_data: SignatureData,
     config: &RocketState<SignatureVerificationConfig>,
-    currency: Json<Currency>
+    currency: Json<Currency>,
 ) -> error::Result<Json<ExchangeAddress>> {
     let currency = currency.into_inner();
     guard_op_signature(
@@ -535,15 +549,21 @@ async fn get_exchange_address(
     };
     let address = match deposit_info {
         Some(address) => Ok(address),
-        None => get_deposit_address(btc_client, eth_client, update_sender, state, currency.clone())
-                    .await
-                    .map_err(|_| error::Error::FailedGenAddress(currency.clone()))
+        None => get_deposit_address(
+            btc_client,
+            eth_client,
+            update_sender,
+            state,
+            currency.clone(),
+        )
+        .await
+        .map_err(|_| error::Error::FailedGenAddress(currency.clone())),
     }?;
     let qr_code: Vec<u8> =
         qrcode_generator::to_png_to_vec(address.address(), QrCodeEcc::Low, 256).unwrap();
-    let addr = ExchangeAddress{ 
-        currency: currency.ticker_lowercase(), 
-        address: address.address(), 
+    let addr = ExchangeAddress {
+        currency: currency.ticker_lowercase(),
+        address: address.address(),
         qr_code_base64: base64::encode(qr_code),
     };
     Ok(Json(addr))
@@ -574,23 +594,23 @@ pub async fn serve_api(
         .mount(
             "/",
             openapi_get_routes![
-                list,                           // GET:  /request/${currency.toLowerCase()} 
-                confirm,                        // POST: /confirm', 
-                reject,                         // POST: /reject',
-                get_hot_wallet_balance,         // GET:  /hot-wallet-balance/${currency.toLowerCase()} 
-                get_supported_currencies,       // GET:  /currencies
-                get_required_confrimations,     // GET:  /confirmations 
-                gen_invite,                     // POST: /invite/generate 
-                list_ops_invites,               // GET:  /invite/listmy 
-                get_all_changes,                // GET:  /changes 
-                confirm_limits,                 // POST: /limits/confirm 
-                reject_limits,                  // POST: /limits/reject 
-                confirm_exchange,               // POST: /exchange/confirm
-                reject_exchange,                // POST: /exchange/reject
-                get_exchange_requests,          // GET:  /exchange/list?filter= <all, pending, completed, rejected>
-                get_exchange_balances,          // GET:  /exchange/balances    
-                get_exchange_address,           // POST: /exchange/address
-                get_user_info,                  // GET: /user/info/<user_id>
+                list,                       // GET:  /request/${currency.toLowerCase()}
+                confirm,                    // POST: /confirm',
+                reject,                     // POST: /reject',
+                get_hot_wallet_balance,     // GET:  /hot-wallet-balance/${currency.toLowerCase()}
+                get_supported_currencies,   // GET:  /currencies
+                get_required_confrimations, // GET:  /confirmations
+                gen_invite,                 // POST: /invite/generate
+                list_ops_invites,           // GET:  /invite/listmy
+                get_all_changes,            // GET:  /changes
+                confirm_limits,             // POST: /limits/confirm
+                reject_limits,              // POST: /limits/reject
+                confirm_exchange,           // POST: /exchange/confirm
+                reject_exchange,            // POST: /exchange/reject
+                get_exchange_requests, // GET:  /exchange/list?filter= <all, pending, completed, rejected>
+                get_exchange_balances, // GET:  /exchange/balances
+                get_exchange_address,  // POST: /exchange/address
+                get_user_info,         // GET: /user/info/<user_id>
             ],
         )
         .mount("/ticker/", ticker_api)

--- a/hexstody-operator/src/api/mod.rs
+++ b/hexstody-operator/src/api/mod.rs
@@ -6,9 +6,13 @@ use qrcode_generator::QrCodeEcc;
 use rocket::{
     fairing::AdHoc,
     fs::{FileServer, NamedFile},
+    futures::stream::Stream,
+    response::stream::{Event, EventStream},
     serde::json::Json,
-    State as RocketState, {get, post, routes, uri},
+    tokio::select,
+    Shutdown, State as RocketState, {get, post, routes, uri},
 };
+
 use rocket_okapi::{openapi, openapi_get_routes, swagger_ui::*};
 use std::{path::PathBuf, str, sync::Arc};
 use tokio::sync::{mpsc, Mutex, Notify};
@@ -482,7 +486,6 @@ async fn reject_exchange(
         .map_err(|e| error::Error::InternalServerError(format!("{:?}", e)).into())
 }
 
-/// # Get all supported currencies
 #[openapi(skip)]
 #[get("/exchange/list?<filter>")]
 async fn get_exchange_requests(
@@ -569,11 +572,32 @@ async fn get_exchange_address(
     Ok(Json(addr))
 }
 
+// NOTE: this handler has no authorization, so it leaks information
+/// Returns an infinite stream of server-sent events.
+/// Each event is a notification that state on the server has changed.
+#[openapi(tag = "State update events")]
+#[get("/state-updates-events")]
+async fn events(
+    state_notify: &RocketState<Arc<Notify>>,
+    mut end: Shutdown,
+) -> EventStream<impl Stream<Item = Event> + '_> {
+    EventStream! {
+        loop {
+            select! {
+                _ = state_notify.notified() => {
+                    yield Event::data("");
+                }
+                _ = &mut end => break,
+            };
+        }
+    }
+}
+
 pub async fn serve_api(
     pool: Pool,
     state: Arc<Mutex<HexstodyState>>,
     runtime_state: Arc<Mutex<RuntimeState>>,
-    _state_notify: Arc<Notify>,
+    state_notify: Arc<Notify>,
     start_notify: Arc<Notify>,
     update_sender: mpsc::Sender<StateUpdate>,
     btc_client: BtcClient,
@@ -611,6 +635,7 @@ pub async fn serve_api(
                 get_exchange_balances, // GET:  /exchange/balances
                 get_exchange_address,  // POST: /exchange/address
                 get_user_info,         // GET: /user/info/<user_id>
+                events,
             ],
         )
         .mount("/ticker/", ticker_api)
@@ -629,6 +654,7 @@ pub async fn serve_api(
         .manage(eth_client)
         .manage(ticker_client)
         .manage(static_path)
+        .manage(state_notify)
         .attach(AdHoc::config::<SignatureVerificationConfig>())
         .attach(on_ready)
         .launch()

--- a/hexstody-operator/static/components/AuthorizedContent.js
+++ b/hexstody-operator/static/components/AuthorizedContent.js
@@ -18,7 +18,7 @@ export const AuthorizedContent = {
                 </nav>
             </header>
             <KeepAlive>
-                <component :is="currentTab" :private-key-jwk="privateKeyJwk" :public-key-der="publicKeyDer"></component>
+                <component :is="currentTab"></component>
             </KeepAlive>
         </div>`,
     data() {
@@ -49,14 +49,4 @@ export const AuthorizedContent = {
             return tabName
         }
     },
-    props: {
-        privateKeyJwk: {
-            type: Object,
-            required: true
-        },
-        publicKeyDer: {
-            type: Object,
-            required: true
-        }
-    }
 }

--- a/hexstody-operator/static/components/CurrencySelect.js
+++ b/hexstody-operator/static/components/CurrencySelect.js
@@ -30,14 +30,5 @@ export const CurrencySelect = {
             this.$emit('currency-selected', this.currencies[event.target.value])
         }
     },
-    props: {
-        privateKeyJwk: {
-            type: Object,
-            required: true
-        },
-        publicKeyDer: {
-            type: Object,
-            required: true
-        }
-    }
+    inject: ['privateKeyJwk', 'publicKeyDer'],
 }

--- a/hexstody-operator/static/components/ExchangeBalance.js
+++ b/hexstody-operator/static/components/ExchangeBalance.js
@@ -43,17 +43,11 @@ export const ExchangeBalance = {
         },
     },
     watch: {
-        currency: 'fetchData'
+        currency: 'fetchData',
+        eventToggle: 'fetchData'
     },
     props: {
-        privateKeyJwk: {
-            type: Object,
-            required: true
-        },
-        publicKeyDer: {
-            type: Object,
-            required: true
-        },
         currency: {}
-    }
+    },
+    inject: ['eventToggle', 'privateKeyJwk', 'publicKeyDer'],
 }

--- a/hexstody-operator/static/components/ExchangeDepositAddress.js
+++ b/hexstody-operator/static/components/ExchangeDepositAddress.js
@@ -37,7 +37,8 @@ export const ExchangeDepositAddress = {
         }
     },
     watch: {
-        currency: 'fetchData'
+        currency: 'fetchData',
+        eventToggle: 'fetchData',
     },
     computed: {
         isAddressLoaded() {
@@ -49,14 +50,7 @@ export const ExchangeDepositAddress = {
         }
     },
     props: {
-        privateKeyJwk: {
-            type: Object,
-            required: true
-        },
-        publicKeyDer: {
-            type: Object,
-            required: true
-        },
         currency: {}
-    }
+    },
+    inject: ['eventToggle', 'privateKeyJwk', 'publicKeyDer'],
 }

--- a/hexstody-operator/static/components/ExchangeRequests.js
+++ b/hexstody-operator/static/components/ExchangeRequests.js
@@ -13,10 +13,10 @@ export const ExchangeRequests = {
     template:
         /*html*/
         `<div>
-            <currency-select :private-key-jwk="privateKeyJwk" :public-key-der="publicKeyDer" @currency-selected="setCurrency" />
-            <exchange-balance :private-key-jwk="privateKeyJwk" :public-key-der="publicKeyDer" :currency="currency" />
-            <exchange-deposit-address :private-key-jwk="privateKeyJwk" :public-key-der="publicKeyDer" :currency="currency" />
-            <exchange-requests-table :private-key-jwk="privateKeyJwk" :public-key-der="publicKeyDer" :currency="currency" />
+            <currency-select @currency-selected="setCurrency" />
+            <exchange-balance :currency="currency" />
+            <exchange-deposit-address :currency="currency" />
+            <exchange-requests-table :currency="currency" />
         </div>`,
     methods: {
         setCurrency(currency) {
@@ -28,14 +28,4 @@ export const ExchangeRequests = {
             currency: null,
         }
     },
-    props: {
-        privateKeyJwk: {
-            type: Object,
-            required: true
-        },
-        publicKeyDer: {
-            type: Object,
-            required: true
-        }
-    }
 }

--- a/hexstody-operator/static/components/ExchangeRequestsTable.js
+++ b/hexstody-operator/static/components/ExchangeRequestsTable.js
@@ -129,17 +129,13 @@ export const ExchangeRequestsTable = {
         }
     },
     async created() {
-        await this.fetchData()
+        this.fetchData()
+    },
+    watch: {
+        eventToggle: 'fetchData'
     },
     props: {
-        privateKeyJwk: {
-            type: Object,
-            required: true
-        },
-        publicKeyDer: {
-            type: Object,
-            required: true
-        },
         currency: {}
-    }
+    },
+    inject: ['eventToggle', 'privateKeyJwk', 'publicKeyDer'],
 }

--- a/hexstody-operator/static/components/HotWalletBalance.js
+++ b/hexstody-operator/static/components/HotWalletBalance.js
@@ -32,6 +32,10 @@ export const HotWalletBalance = {
             isLoading: false
         }
     },
+    watch: {
+        currency: 'fetchData',
+        eventToggle: 'fetchData'
+    },
     computed: {
         isBalanceLoaded() {
             if (typeof this.balance === 'object' && this.balance !== null && "balance" in this.balance) {
@@ -41,18 +45,8 @@ export const HotWalletBalance = {
             }
         }
     },
-    watch: {
-        currency: 'fetchData'
-    },
     props: {
-        privateKeyJwk: {
-            type: Object,
-            required: true
-        },
-        publicKeyDer: {
-            type: Object,
-            required: true
-        },
         currency: {}
     },
+    inject: ['eventToggle', 'privateKeyJwk', 'publicKeyDer'],
 }

--- a/hexstody-operator/static/components/Invites.js
+++ b/hexstody-operator/static/components/Invites.js
@@ -121,14 +121,5 @@ export const Invites = {
             this.showInvites = !this.showInvites
         }
     },
-    props: {
-        privateKeyJwk: {
-            type: Object,
-            required: true
-        },
-        publicKeyDer: {
-            type: Object,
-            required: true
-        }
-    }
+    inject: ['eventSource', 'privateKeyJwk', 'publicKeyDer'],
 }

--- a/hexstody-operator/static/components/WithdrawalLimits.js
+++ b/hexstody-operator/static/components/WithdrawalLimits.js
@@ -110,7 +110,10 @@ export const WithdrawalLimits = {
         },
     },
     async created() {
-        await this.fetchData()
+        this.fetchData()
+    },
+    watch: {
+        eventToggle: 'fetchData'
     },
     data() {
         return {
@@ -119,14 +122,5 @@ export const WithdrawalLimits = {
             filter: "all"
         }
     },
-    props: {
-        privateKeyJwk: {
-            type: Object,
-            required: true
-        },
-        publicKeyDer: {
-            type: Object,
-            required: true
-        },
-    },
+    inject: ['eventToggle', 'privateKeyJwk', 'publicKeyDer'],
 }

--- a/hexstody-operator/static/components/WithdrawalRequests.js
+++ b/hexstody-operator/static/components/WithdrawalRequests.js
@@ -11,9 +11,9 @@ export const WithdrawalRequests = {
     template:
         /*html*/
         `<div>
-            <currency-select :private-key-jwk="privateKeyJwk" :public-key-der="publicKeyDer" @currency-selected="setCurrency" />
-            <hot-wallet-balance :private-key-jwk="privateKeyJwk" :public-key-der="publicKeyDer" :currency="currency" />
-            <withdrawal-requests-table :private-key-jwk="privateKeyJwk" :public-key-der="publicKeyDer" :currency="currency" />
+            <currency-select @currency-selected="setCurrency" />
+            <hot-wallet-balance :currency="currency" />
+            <withdrawal-requests-table :currency="currency" />
         </div>`,
     data() {
         return {
@@ -25,14 +25,4 @@ export const WithdrawalRequests = {
             this.currency = currency
         },
     },
-    props: {
-        privateKeyJwk: {
-            type: Object,
-            required: true
-        },
-        publicKeyDer: {
-            type: Object,
-            required: true
-        }
-    }
 }

--- a/hexstody-operator/static/components/WithdrawalRequestsTable.js
+++ b/hexstody-operator/static/components/WithdrawalRequestsTable.js
@@ -154,7 +154,7 @@ export const WithdrawalRequestsTable = {
         },
         closeModal() {
             this.isModalVisible = false
-        }
+        },
     },
     data() {
         return {
@@ -166,17 +166,11 @@ export const WithdrawalRequestsTable = {
         }
     },
     watch: {
-        currency: 'fetchData'
+        currency: 'fetchData',
+        eventToggle: 'fetchData'
     },
     props: {
-        privateKeyJwk: {
-            type: Object,
-            required: true
-        },
-        publicKeyDer: {
-            type: Object,
-            required: true
-        },
         currency: {}
     },
+    inject: ['eventToggle', 'privateKeyJwk', 'publicKeyDer'],
 }

--- a/hexstody-operator/static/scripts/main.js
+++ b/hexstody-operator/static/scripts/main.js
@@ -5,14 +5,27 @@ const app = Vue.createApp({
     template:
         /*html*/
         `<div class="container">
-            <keyfile-input @key-imported="setKey" @key-reset="resetKey"></keyfile-input>
-            <authorized-content v-if="isAuthorized" :private-key-jwk="privateKeyJwk" :public-key-der="publicKeyDer">
-            </authorized-content>
+            <keyfile-input @key-imported="setKey" @key-reset="resetKey" />
+            <authorized-content v-if="isAuthorized" />
         </div>`,
     data() {
         return {
             privateKeyJwk: null,
-            publicKeyDer: null
+            publicKeyDer: null,
+            eventToggle: false
+        }
+    },
+    provide() {
+        return {
+            eventToggle: Vue.computed(() => this.eventToggle),
+            privateKeyJwk: Vue.computed(() => this.privateKeyJwk),
+            publicKeyDer: Vue.computed(() => this.publicKeyDer)
+        }
+    },
+    created() {
+        const eventSource = new EventSource('/state-updates-events')
+        eventSource.onmessage = (_event) => {
+            this.eventToggle = !this.eventToggle
         }
     },
     methods: {
@@ -36,5 +49,8 @@ app.component("keyfile-input", KeyfileComponent)
 app.component("authorized-content", AuthorizedContent)
 
 app.use(TippyVue)
+
+// Remove this when Vue.js v3.3 comes out
+app.config.unwrapInjectedRef = true
 
 const mountedApp = app.mount('#app')


### PR DESCRIPTION
Now operators dashboard refreshes data on page when server state is changed. Server emits [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events) on each state update.

Also refactored props propagation using [provide / inject](https://vuejs.org/guide/components/provide-inject.html).