### PR TITLE
I201 invoices

### DIFF
--- a/hexstody-api/src/domain/error.rs
+++ b/hexstody-api/src/domain/error.rs
@@ -1,0 +1,152 @@
+use thiserror::Error;
+use crate::domain::{currency::Currency, Erc20Token};
+pub use crate::error::HexstodyError;
+pub use crate::error::Result;
+pub use crate::error::ErrorMessage;
+pub const MIN_USER_NAME_LEN: usize = 3;
+pub const MAX_USER_NAME_LEN: usize = 320;
+pub const MIN_USER_PASSWORD_LEN: usize = 6;
+pub const MAX_USER_PASSWORD_LEN: usize = 1024;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Failed to sign up new user. The user already exists.")]
+    SignupExistedUser,
+    #[error(
+        "Failed to signup user. The user name is too short. Need >= {MIN_USER_NAME_LEN} symbols"
+    )]
+    UserNameTooShort,
+    #[error(
+        "Failed to signup user. The user name is too long. Need <= {MAX_USER_NAME_LEN} symbols"
+    )]
+    UserNameTooLong,
+    #[error("Failed to signup user. The user password is too short. Need >= {MIN_USER_PASSWORD_LEN} symbols")]
+    UserPasswordTooShort,
+    #[error("Failed to signup user. The user password is too long. Need <= {MAX_USER_PASSWORD_LEN} symbols")]
+    UserPasswordTooLong,
+    #[error("Password hash failed: {0}")]
+    Pwhash(#[from] pwhash::error::Error),
+    #[error("Username of password is invalid")]
+    SigninFailed,
+    #[error("Action requires authentification")]
+    AuthRequired,
+    #[error("Authed user is not found in state!")]
+    NoUserFound,
+    #[error("Authed user doesn't have required currency {0}!")]
+    NoUserCurrency(Currency),
+    #[error("Failed to generate new deposit address for currency {0}")]
+    FailedGenAddress(Currency),
+    #[error("Failed to get fee for currency {0}")]
+    FailedGetFee(Currency),
+    #[error("Not enough {0}!")]
+    InsufficientFunds(Currency),
+    #[error("Failed to connect to ETH node: {0}")]
+    FailedETHConnection(String),
+    #[error("{0} is already enabled")]
+    TokenAlreadyEnabled(Erc20Token),
+    #[error("{0} is already disabled")]
+    TokenAlreadyDisabled(Erc20Token),
+    #[error("{0} has non-zero balance. Can not disable")]
+    TokenNonZeroBalance(Erc20Token),
+    #[error("Token action failed: {0}")]
+    TokenActionFailed(String),
+    #[error("Invite does not exist")]
+    InviteNotFound,
+    #[error("Limits are not changed by the update")]
+    LimitsNoChanges,
+    #[error("Limit change not found")]
+    LimChangeNotFound,
+    #[error("Signature error: {0}")]
+    SignatureError(String),
+    #[error("Internal server error: {0}")]
+    InternalServerError(String),
+    #[error("Error: {0}")]
+    GenericError(String),
+    #[error("Unknown currency: {0}")]
+    UnknownCurrency(String),
+    #[error("Language is not changed!")]
+    LangNotChanged,
+    #[error("Invalid e-mail")]
+    InvalidEmail,
+    #[error("Invalid phone number")]
+    InvalidPhoneNumber,
+    #[error("Failed to get {0} exchange rate")]
+    ExchangeRateError(Currency),
+    #[error("Malformed margin: {0}")]
+    MalformedMargin(String),
+}
+
+impl HexstodyError for Error {
+    fn subtype() -> &'static str {
+        "hexstody_api"
+    }
+    fn code(&self) -> u16 {
+        match self {
+            Error::SignupExistedUser => 0,
+            Error::UserNameTooShort => 1,
+            Error::UserNameTooLong => 2,
+            Error::UserPasswordTooShort => 3,
+            Error::UserPasswordTooLong => 4,
+            Error::Pwhash(_) => 5,
+            Error::SigninFailed => 6,
+            Error::AuthRequired => 7,
+            Error::NoUserFound => 8,
+            Error::NoUserCurrency(_) => 9,
+            Error::FailedGenAddress(_) => 10,
+            Error::FailedGetFee(_) => 11,
+            Error::InsufficientFunds(_) => 12,
+            Error::FailedETHConnection(_) => 13,
+            Error::TokenAlreadyEnabled(_) => 14,
+            Error::TokenAlreadyDisabled(_) => 15,
+            Error::TokenNonZeroBalance(_) => 16,
+            Error::TokenActionFailed(_) => 17,
+            Error::InviteNotFound => 18,
+            Error::LimitsNoChanges => 19,
+            Error::LimChangeNotFound => 20,
+            Error::SignatureError(_) => 21,
+            Error::UnknownCurrency(_) => 22,
+            Error::InternalServerError(_) => 23,
+            Error::GenericError(_) => 24,
+            Error::LangNotChanged => 25,
+            Error::InvalidEmail => 26,
+            Error::InvalidPhoneNumber => 27,
+            Error::ExchangeRateError(_) => 28,
+            Error::MalformedMargin(_) => 29,
+        }
+    }
+
+    fn status(&self) -> u16 {
+        match self {
+            Error::SignupExistedUser => 400,
+            Error::UserNameTooShort => 400,
+            Error::UserNameTooLong => 400,
+            Error::UserPasswordTooShort => 400,
+            Error::UserPasswordTooLong => 400,
+            Error::Pwhash(_) => 500,
+            Error::SigninFailed => 401,
+            Error::AuthRequired => 401,
+            Error::NoUserFound => 417,
+            Error::NoUserCurrency(_) => 500,
+            Error::FailedGenAddress(_) => 500,
+            Error::FailedGetFee(_) => 500,
+            Error::InsufficientFunds(_) => 417,
+            Error::FailedETHConnection(_) => 500,
+            Error::TokenAlreadyEnabled(_) => 500,
+            Error::TokenAlreadyDisabled(_) => 500,
+            Error::TokenNonZeroBalance(_) => 500,
+            Error::TokenActionFailed(_) => 500,
+            Error::InviteNotFound => 400,
+            Error::LimitsNoChanges => 500,
+            Error::LimChangeNotFound => 400,
+            Error::SignatureError(_) => 403,
+            Error::InternalServerError(_) => 500,
+            Error::GenericError(_) => 500,
+            Error::UnknownCurrency(_) => 400,
+            Error::LangNotChanged => 400,
+            Error::InvalidEmail => 400,
+            Error::InvalidPhoneNumber => 400,
+            Error::ExchangeRateError(_) => 404,
+            Error::MalformedMargin(_) => 400,
+        }
+    }
+}

--- a/hexstody-api/src/domain/mod.rs
+++ b/hexstody-api/src/domain/mod.rs
@@ -1,4 +1,5 @@
 pub mod currency;
+pub mod error;
 
 use std::str::FromStr;
 pub use currency::*;

--- a/hexstody-eth/src/handlers/accounts.rs
+++ b/hexstody-eth/src/handlers/accounts.rs
@@ -1,13 +1,14 @@
+#![allow(dead_code, unused_variables, non_snake_case)]
 use crate::types::*;
 use crate::node_calls;
 use crate::db_functions;
-use crate::conf::{NodeConfig, load_config};
+use crate::conf::NodeConfig;
 
 use rocket::{get,post,State};
 use rocket::http::{Status, ContentType};
 use rocket::serde::json::Json;
-use rocket_db_pools::{Database, Connection};
-use rocket_okapi::{openapi, openapi_get_routes, swagger_ui::*};
+use rocket_db_pools::Connection;
+use rocket_okapi::openapi;
 
 #[openapi(tag = "accounts")]
 #[get("/createuser/<login>")]

--- a/hexstody-eth/src/handlers/balance.rs
+++ b/hexstody-eth/src/handlers/balance.rs
@@ -2,13 +2,12 @@ use crate::types::*;
 use crate::utils::*;
 use crate::node_calls;
 use crate::db_functions;
-use crate::conf::{NodeConfig, load_config};
+use crate::conf::NodeConfig;
 
-use rocket::{get,post,State};
+use rocket::{get,State};
 use rocket::http::{Status, ContentType};
-use rocket::serde::json::Json;
-use rocket_db_pools::{Database, Connection};
-use rocket_okapi::{openapi, openapi_get_routes, swagger_ui::*};
+use rocket_db_pools::Connection;
+use rocket_okapi::openapi;
 
 #[openapi(tag = "balance")]
 #[get("/balance/eth/total")]
@@ -70,7 +69,7 @@ pub async fn balance_eth_login(login: &str,
                   return (Status::InternalServerError,(ContentType::JSON, "No result error".to_string()));
               }
               Some(res_str) => {
-                  let json_res = serde_json::to_string(&hxt_str_to_f64(res_str));
+                  let _json_res = serde_json::to_string(&hxt_str_to_f64(res_str));
                   log::warn!("=======================</BALANCE ETH>==========================");
                   return (Status::Ok, (ContentType::JSON, format!("{}",&hxt_str_to_f64(res_str))));
               }
@@ -83,7 +82,7 @@ pub async fn balance_eth_login(login: &str,
 #[get("/balance/eth/address/<address>")]
 pub async fn balance_eth_address(address: &str,
                   cfg: &State<NodeConfig>,
-                  db: Connection<MyDb>) -> (Status, (ContentType, String)) {
+                  _db: Connection<MyDb>) -> (Status, (ContentType, String)) {
   log::warn!("=======================<BALANCE ETH>==========================");
   log::warn!("address {:?}",address);
   let r_res = node_calls::balance_eth(cfg,address);
@@ -138,7 +137,7 @@ pub async fn balance_erc20_login(login: &str,
                   return (Status::InternalServerError,(ContentType::JSON, "No result error".to_string()));
               }
               Some(res_str) => {
-                  let json_res = serde_json::to_string(&hxt_str_to_f64(res_str));
+                  let _json_res = serde_json::to_string(&hxt_str_to_f64(res_str));
                   log::warn!("=======================</BALANCE ERC20>==========================");
                   return (Status::Ok, (ContentType::JSON, format!("{}",&hxt_str_to_f64(res_str))));
               }
@@ -152,7 +151,7 @@ pub async fn balance_erc20_login(login: &str,
 pub async fn balance_erc20_address(address: &str,
                   token_address: &str,
                   cfg: &State<NodeConfig>,
-                  db: Connection<MyDb>) -> (Status, (ContentType, String)) {
+                  _db: Connection<MyDb>) -> (Status, (ContentType, String)) {
   log::warn!("=======================<BALANCE ERC20>==========================");
   log::warn!("Address {:?}",address);
   log::warn!("TokenAddress {:?}",token_address);
@@ -175,7 +174,7 @@ pub async fn balance_erc20_address(address: &str,
                   return (Status::InternalServerError,(ContentType::JSON, "No result error".to_string()));
               }
               Some(res_str) => {
-                  let json_res = serde_json::to_string(&hxt_str_to_f64(res_str));
+                  let _json_res = serde_json::to_string(&hxt_str_to_f64(res_str));
                   log::warn!("=======================</BALANCE ERC20>==========================");
                   return (Status::Ok, (ContentType::JSON, format!("{}",&hxt_str_to_f64(res_str))));
               }

--- a/hexstody-eth/src/handlers/common.rs
+++ b/hexstody-eth/src/handlers/common.rs
@@ -1,12 +1,8 @@
-use crate::types::*;
 use crate::node_calls;
-use crate::db_functions;
-use crate::conf::{NodeConfig, load_config};
+use crate::conf::NodeConfig;
 
-use rocket::{get,post,State};
-use rocket::http::{Status, ContentType};
-use rocket::serde::json::Json;
-use rocket_okapi::{openapi, openapi_get_routes, swagger_ui::*};
+use rocket::{get,State};
+use rocket_okapi::openapi;
 
 #[openapi(tag = "version")]
 #[get("/version")]

--- a/hexstody-eth/src/handlers/sending.rs
+++ b/hexstody-eth/src/handlers/sending.rs
@@ -1,23 +1,21 @@
+#![allow(dead_code, unused_variables, non_snake_case)]
 use crate::types::*;
 use crate::utils::*;
 use crate::node_calls;
 use crate::db_functions;
-use crate::conf::{NodeConfig, load_config};
+use crate::conf::NodeConfig;
 
 use rocket::{
-    get,post,State,
+    get,State,
     http::{Status, ContentType},
-    serde::json::Json
 };
 
-use rocket_db_pools::{Database, Connection};
-use rocket_okapi::{openapi, openapi_get_routes, swagger_ui::*};
+use rocket_db_pools::Connection;
+use rocket_okapi::openapi;
 
 use web3::{
-    contract::{Contract, Options},
     ethabi::ethereum_types::U256,
     types::{Address, TransactionParameters,TransactionRequest, H160},
-    api::{Web3Api}
 };
 
 use std::str::FromStr;

--- a/hexstody-eth/src/main.rs
+++ b/hexstody-eth/src/main.rs
@@ -8,32 +8,15 @@ mod worker;
 
 #[macro_use] extern crate rocket;
 
-use hex_literal::hex;
 use worker::*;
 use conf::load_config;
-use conf::NodeConfig;
 use clap::Parser;
 
 use types::*;
-use utils::*;
-
-use std::str::FromStr;
-
-use secp256k1::SecretKey;
-
-use web3::{
-    contract::{Contract, Options},
-    ethabi::ethereum_types::U256,
-    types::{Address, TransactionParameters, H160},
-    api::{Web3Api}
-};
 
 use std::time::Duration;
-use rocket::http::{Status, ContentType};
-use rocket::serde::json::Json;
-use rocket::State;
-use rocket_db_pools::{Database, Connection};
-use rocket_okapi::{openapi, openapi_get_routes, swagger_ui::*};
+use rocket_db_pools::Database;
+use rocket_okapi::{openapi_get_routes, swagger_ui::*};
 
 
 use std::io::Write;

--- a/hexstody-eth/src/node_calls.rs
+++ b/hexstody-eth/src/node_calls.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code, unused_variables, non_snake_case)]
 use crate::types::*;
 use crate::conf::{NodeConfig, load_config};
 

--- a/hexstody-eth/src/utils.rs
+++ b/hexstody-eth/src/utils.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code, unused_variables, non_snake_case)]
 use web3::{
     ethabi::ethereum_types::U256,
 };
@@ -37,7 +38,7 @@ pub fn to_U256(volume: &str) -> U256{
 
 pub fn hxt_str_to_f64(volume: &str) -> f64{
     let res1 : &str = &volume[2..volume.len()].trim_start_matches('0');
-    if (res1.len()==0){
+    if res1.is_empty() {
         return 0.0;
     } else{
         let res_dec = i128::from_str_radix(&res1, 16).unwrap();

--- a/hexstody-operator/src/api/helpers.rs
+++ b/hexstody-operator/src/api/helpers.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 
-use hexstody_api::domain::{CurrencyAddress, EthAccount, BtcAddress, Erc20Token, Erc20};
+use hexstody_api::domain::{error, CurrencyAddress, EthAccount, BtcAddress, Erc20Token, Erc20};
 use hexstody_api::{types::SignatureData, domain::Currency};
-use hexstody_api::error;
 use hexstody_btc_client::client::BtcClient;
 use hexstody_db::update::{StateUpdate, UpdateBody};
 use hexstody_eth_client::client::EthClient;

--- a/hexstody-operator/src/api/mod.rs
+++ b/hexstody-operator/src/api/mod.rs
@@ -21,8 +21,10 @@ use tokio::sync::{mpsc, Mutex, Notify};
 use uuid::Uuid;
 
 use hexstody_api::{
-    domain::Currency,
-    error,
+    domain::{
+        error,
+        Currency
+    },
     types::{
         ConfirmationData, ConfirmationsConfig, ExchangeAddress, ExchangeBalanceItem,
         ExchangeConfirmationData, ExchangeFilter, HotBalanceResponse, Invite, InviteRequest,

--- a/hexstody-public/src/api/auth.rs
+++ b/hexstody-public/src/api/auth.rs
@@ -1,6 +1,6 @@
 use hexstody_api::domain::ChallengeResponse;
 use hexstody_api::domain::Currency;
-use hexstody_api::error;
+use hexstody_api::domain::error;
 use hexstody_api::types as api;
 use hexstody_api::types::PasswordChange;
 use hexstody_api::types::SignatureData;

--- a/hexstody-public/src/api/profile.rs
+++ b/hexstody-public/src/api/profile.rs
@@ -1,11 +1,11 @@
 use std::{sync::Arc, fmt::Debug};
 use base64;
 use hexstody_api::{types::{LimitApiResp, LimitChangeReq, LimitChangeResponse, ConfigChangeRequest, LimitChangeFilter}, domain::{Currency, Language, Email, PhoneNumber, TgName, Unit, CurrencyUnit, UnitInfo, UserUnitInfo}};
-use rocket::{get, http::{CookieJar, Status}, State, serde::json::Json, response::Redirect, post};
+use rocket::{get, http::CookieJar, State, serde::json::Json, response::Redirect, post};
 use rocket_okapi::openapi;
 use tokio::sync::{Mutex, mpsc};
 use hexstody_db::{state::{State as DbState, UserConfig}, update::{StateUpdate, limit::{LimitChangeUpd, LimitCancelData}, UpdateBody, misc::{SetLanguage, ConfigUpdateData, SetPublicKey, SetUnit}}};
-use hexstody_api::error;
+use hexstody_api::domain::error;
 use p256::{pkcs8::DecodePublicKey, PublicKey};
 use super::auth::{require_auth_user, goto_signin};
 
@@ -63,7 +63,7 @@ pub async fn request_new_limits(
     match resp {
         Ok(v) => Ok(Ok(v)),
         // Error code 8 => NoUserFound (not logged in). 7 => Requires auth
-        Err(err) => if err.1.code == 8 || err.1.code == 7 {
+        Err(err) => if err.code == 8 || err.code == 7 {
             Err(goto_signin())
         } else {
             Ok(Err(err))
@@ -110,7 +110,7 @@ pub async fn cancel_user_change(
     match resp {
         Ok(v) => Ok(Ok(v)),
         // Error code 8 => NoUserFound (not logged in). 7 => Requires auth
-        Err(err) => if err.1.code == 8 || err.1.code == 7 {
+        Err(err) => if err.code == 8 || err.code == 7 {
             Err(goto_signin())
         } else {
             Ok(Err(err))
@@ -185,7 +185,7 @@ pub async fn set_user_config(
     }).await
 }
 
-fn to_generic_error<T, E>(e: E) -> Result<T,(Status, rocket::serde::json::Json<error::ErrorMessage>)>
+fn to_generic_error<T, E>(e: E) -> error::Result<T>
 where
 E: Debug
 {

--- a/hexstody-ticker/src/api.rs
+++ b/hexstody-ticker/src/api.rs
@@ -2,8 +2,9 @@ use std::sync::Arc;
 
 use hexstody_api::{
     types::{TickerUsdRub, MarginData},
-    domain::{Currency, Symbol}};
-use hexstody_api::error;
+    domain::{Currency, Symbol}
+};
+use hexstody_api::domain::error as error;
 use hexstody_runtime_db::RuntimeState;
 use hexstody_ticker_provider::client::TickerClient;
 use rocket::{post, State, Route, serde::json::Json};


### PR DESCRIPTION
Refactor error messages:

Define and implement `HexstodyError` trait that allows submodules to define their own error enums without adding anything to hexstody_api error enum.

## Usage

Define custom error enum
``` rust

use thiserror::Error;
use hexstody_api::error::HexstodyError;

/// Must implement Debug and Error (which implements Display)
#[derive(Debug, Error)
pub enum Error {
  #[error("Generic error {0}")]
  GenericError(String)
}

impl HexstodyError for Error {
    /// Subtype defines module name, along with code uniquely identifies error for internal use
    fn subtype() -> &'static str {
        "my_submodule"
    }

    /// Internal error code. Pretty much used for matching a-la if(err.code == 0) {...}
    fn code(&self) -> u16 {
        match self {
            Error::GenericError(_) => 0,
        }
    }

    /// Server status of the error: 400, 403, 500 etc
    fn status(&self) -> u16 {
        match self {
            Error::GenericError(_) => 500,
        }
    }
}
``` 

Voilà! Now you can use `hexstody_api::error::Result` for all situations simply using `.into()` on your custom errors