### PR TITLE
Separate auth and add api-key authorization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,6 +1459,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hexstody-auth"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "hexstody-api",
+ "rocket",
+ "rocket_okapi 0.8.0-rc.2 (git+https://github.com/GREsau/okapi?rev=ddb07a709129b24ed8e106b0fbf576b6ded615ac)",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "uuid 0.8.2",
+]
+[[package]]
 name = "hexstody-btc"
 version = "0.1.0"
 dependencies = [
@@ -1569,6 +1585,7 @@ dependencies = [
  "chrono",
  "futures",
  "hexstody-api",
+ "hexstody-auth",
  "hexstody-btc-api",
  "log",
  "p256",
@@ -1721,6 +1738,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "hexstody-api",
+ "hexstody-auth",
  "hexstody-btc-api",
  "hexstody-btc-client",
  "hexstody-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,5 @@ members = [
     "hexstody-ticker-provider",
     "hexstody-ticker",
     "hexstody-runtime-db",
+    "hexstody-auth"
 ]

--- a/hexstody-auth/Cargo.toml
+++ b/hexstody-auth/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "hexstody-auth"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-trait = "0.1.56"
+chrono = { version = "0.4.19", features = ["serde"] }
+hexstody-api = { path = "../hexstody-api" }
+rocket = { version = "=0.5.0-rc.2", default-features = false, features = [
+  "json",
+  "uuid",
+] }
+rocket_okapi = { git = "https://github.com/GREsau/okapi", rev = "ddb07a709129b24ed8e106b0fbf576b6ded615ac", features = [
+  "rapidoc",
+  "swagger",
+] }
+schemars = { version = "0.8.10", features = ["chrono", "uuid"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0"
+tokio = { version = "1", features = ["full"] }
+uuid = { version = "0.8", features = [ "serde", "v4" ] }

--- a/hexstody-auth/src/error.rs
+++ b/hexstody-auth/src/error.rs
@@ -1,0 +1,30 @@
+use hexstody_api::error::HexstodyError;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Action requires authentification")]
+    AuthRequired,
+    #[error("Authed user is not found in state!")]
+    NoUserFound,
+}
+
+impl HexstodyError for Error {
+    fn subtype() -> &'static str {
+        "hexstody_auth"
+    }
+
+    fn code(&self) -> u16 {
+        match self {
+            Error::AuthRequired => 0,
+            Error::NoUserFound => 1,
+        }
+    }
+
+    fn status(&self) -> u16 {
+        match self {
+            Error::AuthRequired => 403,
+            Error::NoUserFound => 403,
+        }
+    }
+}

--- a/hexstody-auth/src/lib.rs
+++ b/hexstody-auth/src/lib.rs
@@ -1,0 +1,77 @@
+use std::{future::Future, sync::Arc};
+
+use async_trait::async_trait;
+use rocket::{http::CookieJar, State};
+use hexstody_api::error as h_error;
+
+pub mod error;
+pub mod types;
+
+use error::Error;
+use tokio::sync::{Mutex, MutexGuard};
+use types::ApiKey;
+
+pub const AUTH_COOKIE: &str = "user_id";
+
+#[async_trait]
+pub trait HasAuth {
+    fn get_user_id_by_api_key(&self, api_key: ApiKey) -> Option<String>;
+}
+
+pub trait HasUserInfo<I> {
+    fn get_user_info(&self, user_id: &str) -> Option<I>;
+}
+
+/// Helper for implementing endpoints that require authentication
+pub async fn require_auth<F, Fut, S, R>(
+    cookies: &CookieJar<'_>, 
+    api_key: Option<ApiKey>,
+    state: &State<Arc<Mutex<S>>>,
+    future: F
+) -> h_error::Result<R>
+where
+    S: Send + HasAuth,
+    F: FnOnce(String) -> Fut,
+    Fut: Future<Output = h_error::Result<R>>,
+{
+    if let Some(cookie) = cookies.get_private(AUTH_COOKIE) {
+        let user_id = cookie.value().to_string();
+        future(user_id).await
+    } else {
+        if let Some(api_key) = api_key {
+            if let Some(user_id) = state.lock().await.get_user_id_by_api_key(api_key) {
+                future(user_id).await
+            } else {
+                Err(Error::AuthRequired.into())
+            }
+        } else {
+            Err(Error::AuthRequired.into())
+        }
+    }
+}
+
+/// More specific helper than 'require_auth' as it also locks state
+/// for read only and fetches user info.
+pub async fn require_auth_user<F, S, I, Fut, R>(
+    cookies: &CookieJar<'_>,
+    api_key: Option<ApiKey>,
+    state: &State<Arc<Mutex<S>>>,
+    future: F,
+) -> h_error::Result<R>
+where
+    S: Send + HasAuth + HasUserInfo<I>,
+    F: FnOnce(MutexGuard<S>, I) -> Fut,
+    Fut: Future<Output = h_error::Result<R>>,
+{
+    require_auth(cookies, api_key, state, |user_id| async move {
+        {
+            let state = state.lock().await;
+            if let Some(user) = state.get_user_info(&user_id) {
+                future(state, user).await
+            } else {
+                Err(error::Error::NoUserFound.into())
+            }
+        }
+    })
+    .await
+}

--- a/hexstody-auth/src/types.rs
+++ b/hexstody-auth/src/types.rs
@@ -1,0 +1,56 @@
+use async_trait::async_trait;
+use rocket::{http::Status, request::FromRequest, outcome::Outcome};
+use rocket_okapi::{okapi::openapi3::{Parameter, ParameterValue, Object}, request::{RequestHeaderInput, OpenApiFromRequest}};
+use serde::{Serialize, Deserialize};
+
+use crate::error as error;
+
+#[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Clone, Serialize, Deserialize)]
+pub struct ApiKey(String);
+
+#[async_trait]
+impl<'r> FromRequest<'r> for ApiKey {
+    type Error = error::Error;
+
+    async fn from_request(request: &'r rocket::Request<'_>) -> rocket::request::Outcome<Self, Self::Error> {
+        let api_key = request.headers().get_one("ApiKey");
+        match api_key {
+          Some(api_key) => {
+            // check validity
+            Outcome::Success(ApiKey(api_key.to_string()))
+          },
+          // token does not exist
+          None => Outcome::Failure((Status::Unauthorized, error::Error::AuthRequired))
+        }
+    }
+}
+
+impl<'r> OpenApiFromRequest<'r> for ApiKey {
+    fn from_request_input(
+        gen: &mut rocket_okapi::gen::OpenApiGenerator,
+        _name: String,
+        required: bool,
+    ) -> rocket_okapi::Result<rocket_okapi::request::RequestHeaderInput> {
+        let schema = gen.json_schema::<String>();
+        let description = Some("Contains API key for authorization".to_owned(),
+        );
+        let example = Some(serde_json::json!("123e4567-e89b-12d3-a456-426614174000"));
+        Ok(RequestHeaderInput::Parameter(Parameter {
+            name: "Signature-Data".to_owned(),
+            location: "header".to_owned(),
+            description: description,
+            required,
+            deprecated: false,
+            allow_empty_value: false,
+            value: ParameterValue::Schema {
+                style: None,
+                explode: None,
+                allow_reserved: false,
+                schema,
+                example: example,
+                examples: None,
+            },
+            extensions: Object::default(),
+        }))
+    }
+}

--- a/hexstody-db/Cargo.toml
+++ b/hexstody-db/Cargo.toml
@@ -15,6 +15,7 @@ bitcoin_hashes = "0.10.0"
 chrono = { version = "0.4.19", features = [ "serde" ] }
 futures = "0.3.19"
 hexstody-api = { path = "../hexstody-api" }
+hexstody-auth = { path = "../hexstody-auth" }
 hexstody-btc-api = { path = "../hexstody-btc-api" }
 log = "0.4.14"
 p256 = { version = "0.11.1", features = ["serde"] }

--- a/hexstody-db/src/state/mod.rs
+++ b/hexstody-db/src/state/mod.rs
@@ -7,6 +7,8 @@ pub mod withdraw;
 
 pub use btc::*;
 use chrono::prelude::*;
+use hexstody_auth::{HasUserInfo, HasAuth};
+use hexstody_auth::types::ApiKey;
 use log::*;
 pub use network::*;
 use p256::PublicKey;
@@ -63,6 +65,8 @@ pub struct State {
     pub invites: HashMap<Invite, InviteRec>,
     /// Special wallet for exchanges
     pub exchange_state: ExchangeState,
+    /// Map of api keys to user ids
+    pub api_keys: HashMap<ApiKey, UserId>
 }
 
 #[derive(Error, Debug, PartialEq)]
@@ -121,6 +125,18 @@ pub enum StateUpdateErr {
     UnknownCurrency(String),
 }
 
+impl HasUserInfo<UserInfo> for State{
+    fn get_user_info(&self, user_id: &str) -> Option<UserInfo> {
+        self.users.get(user_id).cloned()
+    }
+}
+
+impl HasAuth for State {
+    fn get_user_id_by_api_key(&self, api_key: ApiKey) -> Option<String> {
+        self.api_keys.get(&api_key).cloned()
+    }
+}
+
 impl State {
     pub fn new(network: Network) -> Self {
         State {
@@ -129,6 +145,7 @@ impl State {
             btc_state: BtcState::new(network.btc()),
             invites: HashMap::new(),
             exchange_state: ExchangeState::new(),
+            api_keys: HashMap::new()
         }
     }
 

--- a/hexstody-public/Cargo.toml
+++ b/hexstody-public/Cargo.toml
@@ -16,6 +16,7 @@ futures-channel = "0.3"
 futures-util = "0.3.19"
 hexstody-db = { path = "../hexstody-db" }
 hexstody-api = { path = "../hexstody-api" }
+hexstody-auth = { path = "../hexstody-auth" }
 hexstody-btc-api = { path = "../hexstody-btc-api" }
 hexstody-btc-client = { path = "../hexstody-btc-client" }
 hexstody-eth-client = { path = "../hexstody-eth-client" }

--- a/hexstody-public/src/api/mod.rs
+++ b/hexstody-public/src/api/mod.rs
@@ -5,6 +5,8 @@ pub mod wallet;
 
 use base64;
 use figment::Figment;
+use hexstody_api::error::HexstodyError;
+use hexstody_auth::{require_auth, require_auth_user, AUTH_COOKIE};
 use hexstody_db::state::Network;
 use hexstody_runtime_db::RuntimeState;
 use hexstody_ticker::api::ticker_api;
@@ -20,7 +22,7 @@ use tokio::sync::{Mutex, Notify};
 
 use rocket::fairing::AdHoc;
 use rocket::fs::FileServer;
-use rocket::http::CookieJar;
+use rocket::http::{CookieJar, Cookie};
 use rocket::response::Redirect;
 use rocket::serde::json::Json;
 use rocket::uri;
@@ -73,8 +75,11 @@ fn ping() -> Json<()> {
 
 #[openapi(skip)]
 #[get("/")]
-async fn index(cookies: &CookieJar<'_>) -> Redirect {
-    require_auth(cookies, |_| async { Ok(()) })
+async fn index(
+    cookies: &CookieJar<'_>,
+    state: &State<Arc<Mutex<DbState>>>,
+) -> Redirect {
+    require_auth(cookies, None, state, |_| async { Ok(()) })
         .await
         .map_or(goto_signin(), |_| Redirect::to(uri!(overview)))
 }
@@ -86,7 +91,7 @@ async fn overview(
     state: &State<Arc<Mutex<DbState>>>,
     static_path: &State<StaticPath>,
 ) -> Result<Template, Redirect> {
-    require_auth_user(cookies, state, |_, user| async move {
+    require_auth_user(cookies, None, state, |_, user| async move {
         let page_title = match user.config.language {
             Language::English => "Overview",
             Language::Russian => "Главная",
@@ -131,7 +136,7 @@ async fn profile_page(
     static_path: &State<StaticPath>,
     tab: Option<String>,
 ) -> Result<Template, Redirect> {
-    require_auth_user(cookies, state, |_, user| async move {
+    require_auth_user(cookies, None, state, |_, user| async move {
         let page_title = match user.config.language {
             Language::English => "Profile",
             Language::Russian => "Профиль",
@@ -178,17 +183,21 @@ fn signup() -> Template {
 
 #[openapi(tag = "auth")]
 #[get("/logout")]
-pub async fn logout(cookies: &CookieJar<'_>) -> error::Result<Redirect> {
-    let resp = require_auth(cookies, |cookie| async move {
-        cookies.remove(cookie);
+pub async fn logout(
+    cookies: &CookieJar<'_>,
+    state: &State<Arc<Mutex<DbState>>>,
+) -> error::Result<Redirect> {
+    let resp = require_auth(cookies, None, state, |_| async move {
+        cookies.remove_private(Cookie::named(AUTH_COOKIE));
         Ok(Json(()))
     })
     .await;
     match resp {
-        Ok(_) => Ok(goto_signin()),
-        // Error code 8 => NoUserFound (not logged in). 7 => Requires auth
+        Ok(_) => {
+            Ok(goto_signin())
+        },
         Err(err) => {
-            if err.code == 8 || err.code == 7 {
+            if err.subtype == hexstody_auth::error::Error::subtype() {
                 Ok(goto_signin())
             } else {
                 Err(err)
@@ -208,7 +217,7 @@ async fn deposit(
     update_sender: &State<mpsc::Sender<StateUpdate>>,
     tab: Option<String>,
 ) -> Result<error::Result<Template>, Redirect> {
-    let resp = require_auth_user(cookies, state, |_, user| async move {
+    let resp = require_auth_user(cookies, None, state, |_, user| async move {
         let page_title = match user.config.language {
             Language::English => "Deposit",
             Language::Russian => "Депозит",
@@ -277,9 +286,8 @@ async fn deposit(
     .await;
     match resp {
         Ok(v) => Ok(Ok(v)),
-        // Error code 8 => NoUserFound (not logged in). 7 => Requires auth
         Err(err) => {
-            if err.code == 8 || err.code == 7 {
+            if err.subtype == hexstody_auth::error::Error::subtype() {
                 Err(goto_signin())
             } else {
                 Ok(Err(err))
@@ -296,7 +304,7 @@ async fn withdraw(
     static_path: &State<StaticPath>,
     tab: Option<String>,
 ) -> Result<error::Result<Template>, Redirect> {
-    let resp = require_auth_user(cookies, state, |_, user| async move {
+    let resp = require_auth_user(cookies, None, state, |_, user| async move {
         let page_title = match user.config.language {
             Language::English => "Withdraw",
             Language::Russian => "Вывод",
@@ -343,9 +351,8 @@ async fn withdraw(
     .await;
     match resp {
         Ok(v) => Ok(Ok(v)),
-        // Error code 8 => NoUserFound (not logged in). 7 => Requires auth
         Err(err) => {
-            if err.code == 8 || err.code == 7 {
+            if err.subtype == hexstody_auth::error::Error::subtype() {
                 Err(goto_signin())
             } else {
                 Ok(Err(err))
@@ -362,7 +369,7 @@ async fn get_dict(
     static_path: &State<StaticPath>,
     path: PathBuf,
 ) -> error::Result<serde_json::Value> {
-    require_auth_user(cookies, state, |_, user| async move {
+    require_auth_user(cookies, None, state, |_, user| async move {
         get_dict_json(static_path.inner(), user.config.language, path)
     })
     .await
@@ -375,7 +382,7 @@ async fn swap(
     state: &State<Arc<Mutex<DbState>>>,
     static_path: &State<StaticPath>,
 ) -> Result<Template, Redirect> {
-    require_auth_user(cookies, state, |_, user| async move {
+    require_auth_user(cookies, None, state, |_, user| async move {
         let mut currencies: Vec<Currency> = user.currencies.keys().cloned().collect();
         currencies.sort();
         let currencies: Vec<String> = currencies.into_iter().map(|c| c.symbol().symbol()).collect();

--- a/hexstody-public/src/api/profile.rs
+++ b/hexstody-public/src/api/profile.rs
@@ -1,21 +1,24 @@
 use std::{sync::Arc, fmt::Debug};
 use base64;
 use hexstody_api::{types::{LimitApiResp, LimitChangeReq, LimitChangeResponse, ConfigChangeRequest, LimitChangeFilter}, domain::{Currency, Language, Email, PhoneNumber, TgName, Unit, CurrencyUnit, UnitInfo, UserUnitInfo}};
+use hexstody_auth::{types::ApiKey, require_auth_user};
 use rocket::{get, http::CookieJar, State, serde::json::Json, response::Redirect, post};
 use rocket_okapi::openapi;
 use tokio::sync::{Mutex, mpsc};
 use hexstody_db::{state::{State as DbState, UserConfig}, update::{StateUpdate, limit::{LimitChangeUpd, LimitCancelData}, UpdateBody, misc::{SetLanguage, ConfigUpdateData, SetPublicKey, SetUnit}}};
 use hexstody_api::domain::error;
 use p256::{pkcs8::DecodePublicKey, PublicKey};
-use super::auth::{require_auth_user, goto_signin};
+
+use super::auth::goto_signin;
 
 #[openapi(tag = "profile")]
 #[get("/profile/limits/get")]
 pub async fn get_user_limits(
     cookies: &CookieJar<'_>,
+    api_key: Option<ApiKey>,
     state: &State<Arc<Mutex<DbState>>>,
 ) -> Result<Json<Vec<LimitApiResp>>, Redirect>{
-    require_auth_user(cookies, state, |_, user| async move {
+    require_auth_user(cookies, api_key, state, |_, user| async move {
         let mut infos: Vec<LimitApiResp> = user.currencies.values().map(|cur_info| 
             LimitApiResp{ 
                 limit_info: cur_info.limit_info.clone(), 
@@ -30,12 +33,13 @@ pub async fn get_user_limits(
 #[post("/profile/limits", data="<new_limits>")]
 pub async fn request_new_limits(
     cookies: &CookieJar<'_>,
+    api_key: Option<ApiKey>,
     state: &State<Arc<Mutex<DbState>>>,
     updater: &State<mpsc::Sender<StateUpdate>>,
     new_limits: Json<Vec<LimitChangeReq>>
 ) -> Result<error::Result<()>, Redirect> {
     let new_limits = new_limits.into_inner();
-    let resp = require_auth_user(cookies, state, |_, user| async move {
+    let resp = require_auth_user(cookies, api_key, state, |_, user| async move {
         let filtered_limits : Vec<LimitChangeUpd> = new_limits.into_iter().filter_map(|l| {
             match user.currencies.get(&l.currency) {
                 None => None,
@@ -75,11 +79,12 @@ pub async fn request_new_limits(
 #[get("/profile/limits/changes?<filter>")]
 pub async fn get_user_limit_changes(
     cookies: &CookieJar<'_>,
+    api_key: Option<ApiKey>,
     state: &State<Arc<Mutex<DbState>>>,
     filter: Option<LimitChangeFilter>
 ) -> Result<Json<Vec<LimitChangeResponse>>, Redirect>{
     let filter = filter.unwrap_or(LimitChangeFilter::All);
-    require_auth_user(cookies, state, |_, user| async move {
+    require_auth_user(cookies, api_key, state, |_, user| async move {
         let changes = user.limit_change_requests
             .values()
             .filter_map(|v| if v.matches_filter(filter) { Some(v.clone().into()) } else {None})
@@ -92,11 +97,12 @@ pub async fn get_user_limit_changes(
 #[post("/profile/limits/cancel", data="<currency>")]
 pub async fn cancel_user_change(
     cookies: &CookieJar<'_>,
+    api_key: Option<ApiKey>,
     state: &State<Arc<Mutex<DbState>>>,
     updater: &State<mpsc::Sender<StateUpdate>>,
     currency: Json<Currency>
 ) -> Result<error::Result<()>, Redirect>{
-    let resp = require_auth_user(cookies, state, |_, user| async move {
+    let resp = require_auth_user(cookies, api_key, state, |_, user| async move {
         match user.limit_change_requests.get(&currency){
             Some(v) => {
                 let state_update = StateUpdate::new(UpdateBody::CancelLimitChange(
@@ -122,12 +128,13 @@ pub async fn cancel_user_change(
 #[post("/profile/language", data="<lang>")]
 pub async fn set_language(
     cookies: &CookieJar<'_>,
+    api_key: Option<ApiKey>,
     state: &State<Arc<Mutex<DbState>>>,
     updater: &State<mpsc::Sender<StateUpdate>>,
     lang: Json<Language>
 ) -> error::Result<()> {
     let lang = lang.into_inner();
-    require_auth_user(cookies, state, |_, user| async move {
+    require_auth_user(cookies, api_key, state, |_, user| async move {
         if user.config.language == lang {
             Err(error::Error::LimitsNoChanges.into())
         } else {
@@ -141,9 +148,10 @@ pub async fn set_language(
 #[get("/profile/settings/config")]
 pub async fn get_user_config(
     cookies: &CookieJar<'_>,
+    api_key: Option<ApiKey>,
     state: &State<Arc<Mutex<DbState>>>,
 ) -> error::Result<Json<UserConfig>>{
-    require_auth_user(cookies, state, |_, user| async move {
+    require_auth_user(cookies, api_key, state, |_, user| async move {
         Ok(Json(user.config))
     }).await
 }
@@ -151,11 +159,12 @@ pub async fn get_user_config(
 #[post("/profile/settings/config", data="<request>")]
 pub async fn set_user_config(
     cookies: &CookieJar<'_>,
+    api_key: Option<ApiKey>,
     state: &State<Arc<Mutex<DbState>>>,
     updater: &State<mpsc::Sender<StateUpdate>>,
     request: Json<ConfigChangeRequest>
 ) -> error::Result<()> {
-    require_auth_user(cookies, state, |_, user| async move {
+    require_auth_user(cookies, api_key, state, |_, user| async move {
         let req = request.into_inner();
         let mut upd_data = ConfigUpdateData::default();
         upd_data.user = user.username;
@@ -196,11 +205,12 @@ E: Debug
 #[post("/profile/key", data="<key_b64>")]
 pub async fn set_user_public_key(
     cookies: &CookieJar<'_>,
+    api_key: Option<ApiKey>,
     state: &State<Arc<Mutex<DbState>>>,
     updater: &State<mpsc::Sender<StateUpdate>>,
     key_b64: Option<Json<String>>
 ) -> error::Result<()> {
-    require_auth_user(cookies, state, |_, user| async move {
+    require_auth_user(cookies, api_key, state, |_, user| async move {
     let mut upd = SetPublicKey { user: user.username, public_key: None };
     if let Some(key_bytes) = key_b64 {
         match base64::decode(key_bytes.into_inner()){
@@ -224,12 +234,13 @@ pub async fn set_user_public_key(
 #[post("/profile/unit/set", data="<unit_reqs>")]
 pub async fn set_unit(
     cookies: &CookieJar<'_>,
+    api_key: Option<ApiKey>,
     state: &State<Arc<Mutex<DbState>>>,
     updater: &State<mpsc::Sender<StateUpdate>>,
     unit_reqs: Json<Vec<Unit>>
 ) -> error::Result<()> {
     let unit_reqs = unit_reqs.into_inner();
-    require_auth_user(cookies, state, |_, user| async move {
+    require_auth_user(cookies, api_key, state, |_, user| async move {
         for unit_req in unit_reqs {
             let cur = unit_req.currency().ok_or(error::Error::UnknownCurrency(unit_req.name()))?;
             let cinfo = user.currencies.get(&cur).ok_or(error::Error::NoUserCurrency(cur))?;
@@ -245,11 +256,12 @@ pub async fn set_unit(
 #[post("/profile/unit/get", data="<currency>")]
 pub async fn get_unit(
     cookies: &CookieJar<'_>,
+    api_key: Option<ApiKey>,
     state: &State<Arc<Mutex<DbState>>>,
     currency: Json<Currency>
 ) -> error::Result<Json<Unit>> {
     let currency = currency.into_inner();
-    require_auth_user(cookies, state, |_, user| async move {
+    require_auth_user(cookies, api_key, state, |_, user| async move {
         let cinfo = user.currencies.get(&currency).ok_or(error::Error::NoUserCurrency(currency))?;
         Ok(Json(cinfo.unit.clone()))
     }).await
@@ -259,9 +271,10 @@ pub async fn get_unit(
 #[get("/profile/unit/all")]
 pub async fn get_all_units(
     cookies: &CookieJar<'_>,
+    api_key: Option<ApiKey>,
     state: &State<Arc<Mutex<DbState>>>,
 ) -> error::Result<Json<Vec<UserUnitInfo>>> {
-    require_auth_user(cookies, state, |_, user| async move {
+    require_auth_user(cookies, api_key, state, |_, user| async move {
         let units: Vec<UnitInfo> =  user.currencies.values()
             .filter_map(|cinfo|
                 if cinfo.unit.is_generic() {


### PR DESCRIPTION
Separate authorization into separate library. 

### `hexstody-auth`

New traits:
``` rust
pub trait HasAuth {
    fn get_user_id_by_api_key(&self, api_key: ApiKey) -> Option<String>;
}

pub trait HasUserInfo<I> {
    fn get_user_info(&self, user_id: &str) -> Option<I>;
}
```

`hexstody-db::state::State` implements both, which allows it to use these helpers:

``` rust
/// Helper for implementing endpoints that require authentication
pub async fn require_auth<F, Fut, S, R>(
    cookies: &CookieJar<'_>, 
    api_key: Option<ApiKey>,
    state: &State<Arc<Mutex<S>>>,
    future: F
) -> h_error::Result<R>
where
    S: Send + HasAuth,
    F: FnOnce(String) -> Fut,
    Fut: Future<Output = h_error::Result<R>> {...}

/// More specific helper than 'require_auth' as it also locks state
/// for read only and fetches user info.
pub async fn require_auth_user<F, S, I, Fut, R>(
    cookies: &CookieJar<'_>,
    api_key: Option<ApiKey>,
    state: &State<Arc<Mutex<S>>>,
    future: F,
) -> h_error::Result<R>
where
    S: Send + HasAuth + HasUserInfo<I>,
    F: FnOnce(MutexGuard<S>, I) -> Fut,
    Fut: Future<Output = h_error::Result<R>> {}
```

This separation is done so that independent submodules can use authorization without dependence on concrete State type